### PR TITLE
fix: 출석/공지 알림 중복 발송 (cron 누적 + 발송 멱등성)

### DIFF
--- a/bin/mju-attendance-alert
+++ b/bin/mju-attendance-alert
@@ -327,6 +327,31 @@ PY
     [[ -z "$ID" || ( -z "$COURSE" && -z "$LECTURE_NO" ) ]] && { usage; exit 1; }
 
     UDIR=$(user_dir "$ID")
+
+    # 멱등 marker — 같은 사용자/날짜/수업 조합으로는 하루 한 번만 발송. cron이 어떤
+    # 이유(중복 등록, 재시도)로 두 번 이상 발사되어도 두 번째부터는 여기서 일찍 종료.
+    # cron이 Asia/Seoul로 발사되므로 marker 키도 KST 기준 날짜로 통일.
+    #
+    # 같은 슬롯에 cron이 6개 등록된 경우 OpenClaw가 같은 분에 6개를 동시 발사할 수
+    # 있다. 단순한 `[[ -e ]] + : >` 패턴은 6개가 모두 존재 검사를 통과한 뒤 모두
+    # 파일을 쓰는 TOCTOU race가 있어 실제로는 막지 못한다. `set -o noclobber` + `>`로
+    # 파일 생성 자체를 atomic lock으로 사용해 한 프로세스만 통과시킨다.
+    TODAY=$(TZ=Asia/Seoul date +%F)
+    if [[ -n "$LECTURE_NO" ]]; then
+      MARKER_KEY="$LECTURE_NO"
+    else
+      # course title은 다국어/특수문자 가능 — 파일명에 안전한 형태로 sanitize.
+      MARKER_KEY=$(printf '%s' "$COURSE" | tr -c '[:alnum:]가-힣' '_' | cut -c1-60)
+      [[ -z "$MARKER_KEY" ]] && MARKER_KEY="course"
+    fi
+    MARKER_DIR="$UDIR/.alert-sent"
+    MARKER_FILE="$MARKER_DIR/attendance-$TODAY-$MARKER_KEY.flag"
+    mkdir -p "$MARKER_DIR"
+    if ! (set -o noclobber; : > "$MARKER_FILE") 2>/dev/null; then
+      # 이미 다른 프로세스가 marker를 잡은 상태 — 중복 발송 방지를 위해 즉시 종료.
+      exit 0
+    fi
+
     if [[ -n "$LECTURE_NO" ]]; then
       if ! RES=$(mju ucheck attendance --lecture-no "$LECTURE_NO" --app-dir "$UDIR" --format json 2>&1); then
         exit 0
@@ -379,13 +404,20 @@ print("\n".join(lines))
 PY
 )
 
-    [[ -z "$CONTENT" ]] && exit 0
+    if [[ -z "$CONTENT" ]]; then
+      # 발송할 본문이 없는 경우(오늘 세션 없음 / 이미 출석 체크됨)에는 marker가 의미 없음.
+      # 다만 marker는 이미 atomic create로 잡혔으니, 다음 호출이 재시도하도록 풀어둔다.
+      rm -f "$MARKER_FILE"
+      exit 0
+    fi
 
     # OpenClaw discord 채널은 비활성화되어 있고 봇 토큰은 mjuclaw-router가 단독
     # 소유한다. 따라서 outbound DM은 router HTTP `POST /discord/send`로 위임한다.
     ROUTER_URL="${MJUCLAW_ROUTER_URL:-http://mjuclaw-router:3100}"
     ROUTER_TOKEN="${MJUCLAW_ROUTER_TOKEN-}"
     if [[ -z "$ROUTER_TOKEN" ]]; then
+      # send 불가 — marker 롤백해 다음 cron 발사가 재시도할 수 있도록.
+      rm -f "$MARKER_FILE"
       echo "ERR: MJUCLAW_ROUTER_TOKEN env가 비어있어 router로 DM을 보낼 수 없습니다." >&2
       exit 1
     fi
@@ -406,11 +438,14 @@ PY
     if [[ "$HTTP_CODE" != "200" ]]; then
       RESP_BODY=$(cat "$HTTP_OUT" 2>/dev/null || true)
       rm -f "$HTTP_OUT"
+      # send 실패는 marker 롤백 — 다음 cron 발사가 재시도할 수 있어야 한다.
+      rm -f "$MARKER_FILE"
       echo "ERR: router /discord/send → HTTP $HTTP_CODE: ${RESP_BODY:-<no body>}" >&2
       exit 1
     fi
     rm -f "$HTTP_OUT"
 
+    # 발송 성공 — marker는 이미 atomic create로 만들어진 상태이므로 그대로 유지.
     printf '%s\n' "$CONTENT"
     ;;
 

--- a/bin/mju-attendance-alert
+++ b/bin/mju-attendance-alert
@@ -34,18 +34,38 @@ Usage:
 EOF
 }
 
-# 유저의 모든 attendance-<id>-* cron 제거
+# 유저의 모든 attendance-<id>-* cron 제거 (config의 cronJobName에 없는 것만).
+# 실패 시 return 1. 호출자가 cron 누적 위험을 인지할 수 있도록.
+#
+# 과거 결함: cron list 실패를 silent(`2>/dev/null || true`)로 흘렸기 때문에 gateway
+# 미준비 시점에 호출되면 jobs를 빈 list로 보고 stale을 못 지우고, 새 generation cron만
+# 누적되었다 (#duplicate-attendance-alerts).
 remove_stale_crons() {
   local id="$1"
   local config_path="${2-}"
   local prefix
   prefix=$(job_prefix "$id")
-  local jobs_json
-  jobs_json=$(openclaw cron list --json 2>/dev/null || true)
-  PREFIX="$prefix" CONFIG_PATH="$config_path" CRON_LIST_JSON="$jobs_json" python3 - <<'PY' 2>/dev/null || true
+
+  local jobs_json=""
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if jobs_json=$(openclaw cron list --json 2>/dev/null) && [[ -n "$jobs_json" ]]; then
+      break
+    fi
+    jobs_json=""
+    sleep 1
+  done
+
+  if [[ -z "$jobs_json" ]]; then
+    echo "ERR remove_stale_crons: openclaw cron list failed for $id after 5 retries; skipping cleanup to avoid masking failure" >&2
+    return 1
+  fi
+
+  PREFIX="$prefix" CONFIG_PATH="$config_path" CRON_LIST_JSON="$jobs_json" python3 - <<'PY'
 import json
 import os
 import subprocess
+import sys
 
 prefix = os.environ["PREFIX"]
 config_path = os.environ.get("CONFIG_PATH", "")
@@ -61,18 +81,35 @@ if config_path:
             if course.get("cronJobName")
         }
     except Exception:
-        keep = set()
+        # config 읽기 실패는 keep을 빈 set으로 두면 모든 attend-<id>- cron이 정리 대상이 된다.
+        # subscribe 직후엔 절대 일어나선 안 되는 상태이므로 명확히 abort.
+        print(f"ERR remove_stale_crons: failed to read config {config_path}", file=sys.stderr)
+        sys.exit(1)
 
 try:
-    data = json.loads(os.environ["CRON_LIST_JSON"] or "[]")
+    data = json.loads(os.environ["CRON_LIST_JSON"])
     jobs = data.get("jobs", []) if isinstance(data, dict) else data
-except Exception:
-    raise SystemExit(0)
+except Exception as exc:
+    print(f"ERR remove_stale_crons: invalid cron list JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
 
+failures = []
 for job in jobs:
     name = job.get("name", "")
     if name.startswith(prefix) and name not in keep:
-        subprocess.run(["openclaw", "cron", "rm", job.get("id") or name], check=False, capture_output=True)
+        result = subprocess.run(
+            ["openclaw", "cron", "rm", job.get("id") or name],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            failures.append((name, (result.stderr or result.stdout or "").strip()))
+
+if failures:
+    for name, msg in failures:
+        print(f"ERR remove_stale_crons: failed to remove {name}: {msg}", file=sys.stderr)
+    sys.exit(1)
 PY
 }
 
@@ -233,13 +270,20 @@ PY
     fi
 
     mv "$CONFIG_TMP" "$CONFIG_PATH"
-    remove_stale_crons "$ID" "$CONFIG_PATH"
+    # config는 swap 됐고 새 cron도 등록 완료. stale 정리가 실패해도 subscribe 자체는
+    # 성공이지만, 옛 cron이 남아 같은 알림이 N번 갈 수 있으므로 stderr로 명확히 경고.
+    if ! remove_stale_crons "$ID" "$CONFIG_PATH"; then
+      echo "WARN: stale cron 정리 실패. 다음 subscribe 호출 시 다시 시도됩니다." >&2
+    fi
     ;;
 
   unsubscribe)
     ID="${1-}"
     [[ -z "$ID" ]] && { usage; exit 1; }
-    remove_all_crons "$ID"
+    if ! remove_all_crons "$ID"; then
+      echo "ERR: cron 제거 실패. 재시도 필요." >&2
+      exit 1
+    fi
     rm -f "$(config_file "$ID")"
     echo "OK: unsubscribed $ID"
     ;;

--- a/bin/mju-attendance-alert
+++ b/bin/mju-attendance-alert
@@ -1,8 +1,8 @@
 #!/bin/bash
-# mju-attendance-alert: 수업 시작 N분 후에 출석 체크 안돼있으면 DM 알림
+# mju-attendance-alert: 출석 인정 종료 5분 전에 출석 체크 안돼있으면 DM 알림
 #
 # 동작:
-#   subscribe  — mju msi timetable로 시간표 가져와서 각 수업마다 (시작+grace)분 cron 등록
+#   subscribe  — mju ucheck alert-plan으로 수업별 출석 인정 시간을 읽고 cron 등록
 #   unsubscribe — 유저 관련 모든 attendance cron 제거
 #   check      — cron이 호출. 특정 과목 오늘 출석 상태 확인, 미체크면 직접 DM 전송
 #   refresh    — 시간표 변경 시 cron 재생성 (unsubscribe + subscribe)
@@ -20,32 +20,48 @@ fi
 
 user_dir() { printf '/data/users/%s\n' "$1"; }
 config_file() { printf '%s/attendance-alert.json\n' "$(user_dir "$1")"; }
-job_prefix() { printf 'attend-%s\n' "$1"; }
+job_prefix() { printf 'attend-%s-\n' "$1"; }
 
 usage() {
   cat <<EOF
 Usage:
-  mju-attendance-alert subscribe <discord_id> [grace_min=10]
+  mju-attendance-alert subscribe <discord_id> [lead_min=5]
   mju-attendance-alert unsubscribe <discord_id>
   mju-attendance-alert refresh <discord_id>
   mju-attendance-alert status <discord_id>
-  mju-attendance-alert check <discord_id> "<course_title>"
+  mju-attendance-alert check <discord_id> "<course_title>" [lecture_no]
+  mju-attendance-alert check <discord_id> --lecture-no <lecture_no>
 EOF
 }
 
 # 유저의 모든 attendance-<id>-* cron 제거
-remove_all_crons() {
+remove_stale_crons() {
   local id="$1"
+  local config_path="${2-}"
   local prefix
   prefix=$(job_prefix "$id")
   local jobs_json
   jobs_json=$(openclaw cron list --json 2>/dev/null || true)
-  PREFIX="$prefix" CRON_LIST_JSON="$jobs_json" python3 - <<'PY' 2>/dev/null || true
+  PREFIX="$prefix" CONFIG_PATH="$config_path" CRON_LIST_JSON="$jobs_json" python3 - <<'PY' 2>/dev/null || true
 import json
 import os
 import subprocess
 
 prefix = os.environ["PREFIX"]
+config_path = os.environ.get("CONFIG_PATH", "")
+keep = set()
+
+if config_path:
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            config = json.load(f)
+        keep = {
+            course.get("cronJobName")
+            for course in config.get("courses", [])
+            if course.get("cronJobName")
+        }
+    except Exception:
+        keep = set()
 
 try:
     data = json.loads(os.environ["CRON_LIST_JSON"] or "[]")
@@ -55,24 +71,26 @@ except Exception:
 
 for job in jobs:
     name = job.get("name", "")
-    if name.startswith(prefix):
+    if name.startswith(prefix) and name not in keep:
         subprocess.run(["openclaw", "cron", "rm", job.get("id") or name], check=False, capture_output=True)
 PY
+}
+
+remove_all_crons() {
+  remove_stale_crons "$1"
 }
 
 case "$CMD" in
   subscribe)
     ID="${1-}"
-    GRACE="${2-10}"
+    LEAD="${2-5}"
     [[ -z "$ID" ]] && { usage; exit 1; }
 
     UDIR=$(user_dir "$ID")
     mkdir -p "$UDIR"
 
-    remove_all_crons "$ID"
-
-    if ! TT=$(mju msi timetable --app-dir "$UDIR" --format json 2>&1); then
-      echo "ERR: 시간표 조회 실패. 먼저 로그인이 필요합니다." >&2
+    if ! PLAN=$(mju ucheck alert-plan --lead-minutes "$LEAD" --app-dir "$UDIR" --format json 2>&1); then
+      echo "ERR: 출석 알림 계획 조회 실패. 먼저 로그인이 필요합니다." >&2
       exit 1
     fi
 
@@ -81,57 +99,60 @@ case "$CMD" in
     mkdir -p "$CONFIG_DIR"
     CONFIG_TMP=$(mktemp "$CONFIG_DIR/.attendance-alert.XXXXXX")
 
-    if ! TIMETABLE_JSON="$TT" GRACE_MIN="$GRACE" USER_ID="$ID" CONFIG_TMP="$CONFIG_TMP" python3 - <<'PY'
+    if ! ALERT_PLAN_JSON="$PLAN" LEAD_MIN="$LEAD" USER_ID="$ID" CONFIG_TMP="$CONFIG_TMP" python3 - <<'PY'
 import json
 import os
 import re
 import shlex
 import subprocess
 import sys
+import uuid
 from datetime import datetime, timezone
 
 def cleanup(names):
     for name in names:
         subprocess.run(["openclaw", "cron", "rm", name], check=False, capture_output=True, text=True)
 
-data = json.loads(os.environ["TIMETABLE_JSON"])
-entries = data.get("entries", [])
-grace = int(os.environ["GRACE_MIN"])
+data = json.loads(os.environ["ALERT_PLAN_JSON"])
+schedules = data.get("schedules", [])
+lead = int(os.environ["LEAD_MIN"])
 user_id = os.environ["USER_ID"]
 config_tmp = os.environ["CONFIG_TMP"]
 
 seen = set()
 registered = []
 registered_names = []
+generation = f"{datetime.now(timezone.utc):%Y%m%d%H%M%S}-{uuid.uuid4().hex[:8]}"
 
 try:
-    for entry in entries:
-        dow = entry.get("dayOfWeek")
-        if not dow or dow > 5:
+    for schedule in schedules:
+        dow = schedule.get("cronDayOfWeek", schedule.get("dayOfWeek"))
+        if dow is None or dow < 0 or dow > 6:
             continue
 
-        time_range = entry.get("timeRange", "")
-        # quoted heredoc(<<'PY')을 통해 넘어오기 때문에 백슬래시가 그대로 전달된다.
-        # 따라서 raw string에서 \d 한 번만 써야 regex engine이 digit로 해석한다.
-        match = re.match(r"(\d{1,2}):(\d{2})", time_range)
+        alert_time = schedule.get("alertTime", "")
+        match = re.match(r"^(\d{1,2}):(\d{2})$", alert_time)
         if not match:
             continue
 
-        hour, minute = int(match.group(1)), int(match.group(2))
-        total = hour * 60 + minute + grace
-        alert_h = (total // 60) % 24
-        alert_m = total % 60
+        alert_h, alert_m = int(match.group(1)), int(match.group(2))
 
-        title = entry.get("courseTitle", "")
-        key = f"{dow}-{alert_h:02d}{alert_m:02d}-{title}"
+        title = schedule.get("courseTitle", "")
+        lecture_no = schedule.get("lectureNo")
+        key = f"{dow}-{alert_h:02d}{alert_m:02d}-{lecture_no or title}"
         if key in seen:
             continue
         seen.add(key)
 
         cron_expr = f"{alert_m} {alert_h} * * {dow}"
         slug = re.sub(r"[^가-힣a-zA-Z0-9]", "", title)[:20] or "course"
-        job_name = f"attend-{user_id}-{dow}-{alert_h:02d}{alert_m:02d}-{slug}"
-        check_cmd = f"mju-attendance-alert check {shlex.quote(user_id)} {shlex.quote(title)}"
+        suffix = str(lecture_no) if lecture_no else slug
+        job_name = f"attend-{user_id}-{generation}-{dow}-{alert_h:02d}{alert_m:02d}-{suffix}"
+        if lecture_no:
+            check_parts = ["mju-attendance-alert", "check", user_id, "--lecture-no", str(lecture_no)]
+        else:
+            check_parts = ["mju-attendance-alert", "check", user_id, title]
+        check_cmd = " ".join(shlex.quote(part) for part in check_parts)
         message = f"다음을 정확히 실행: exec로 {check_cmd} 를 실행하고, 추가 명령 없이 <final></final>로 종료."
 
         result = subprocess.run(
@@ -163,22 +184,40 @@ try:
             raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"failed to add cron {job_name}")
 
         registered_names.append(job_name)
-        registered.append({"day": dow, "time": f"{alert_h:02d}:{alert_m:02d}", "course": title})
+        registered.append({
+            "cronJobName": job_name,
+            "day": dow,
+            "dayLabel": schedule.get("dayLabel", ""),
+            "time": f"{alert_h:02d}:{alert_m:02d}",
+            "course": title,
+            "lectureNo": lecture_no,
+            "startTime": schedule.get("startTime", ""),
+            "endTime": schedule.get("endTime", ""),
+            "timeRange": schedule.get("timeRange", ""),
+            "attendEndMinute": schedule.get("attendEndMinute"),
+            "lateEndMinute": schedule.get("lateEndMinute"),
+            "alertAfterStartMinute": schedule.get("alertAfterStartMinute"),
+            "sessionCount": schedule.get("sessionCount", 0),
+        })
 
     config = {
         "enabled": True,
-        "graceMin": grace,
+        "leadMinutes": lead,
         "timezone": "Asia/Seoul",
         "subscribedAt": datetime.now(timezone.utc).isoformat(),
+        "planYear": data.get("year"),
+        "planTerm": data.get("term"),
+        "warnings": data.get("warnings", []),
         "courses": registered,
     }
     with open(config_tmp, "w", encoding="utf-8") as f:
         json.dump(config, f, indent=2, ensure_ascii=False)
 
     print(f"OK: {len(registered)}개 수업 알림 등록됨")
-    days = ["", "월", "화", "수", "목", "금"]
+    days = ["일", "월", "화", "수", "목", "금", "토"]
     for item in registered:
-        print(f"  - {days[item['day']]} {item['time']} : {item['course']}")
+        day_label = item.get("dayLabel") or days[item["day"]]
+        print(f"  - {day_label} {item['time']} : {item['course']}")
 except Exception as exc:
     cleanup(registered_names)
     try:
@@ -194,6 +233,7 @@ PY
     fi
 
     mv "$CONFIG_TMP" "$CONFIG_PATH"
+    remove_stale_crons "$ID" "$CONFIG_PATH"
     ;;
 
   unsubscribe)
@@ -209,15 +249,16 @@ PY
     [[ -z "$ID" ]] && { usage; exit 1; }
     F=$(config_file "$ID")
     [[ ! -f "$F" ]] && { echo "ERR: 구독 정보 없음. subscribe 먼저 실행." >&2; exit 1; }
-    GRACE=$(FILE_PATH="$F" python3 - <<'PY'
+    LEAD=$(FILE_PATH="$F" python3 - <<'PY'
 import json
 import os
 
 with open(os.environ["FILE_PATH"], encoding="utf-8") as f:
-    print(json.load(f).get("graceMin", 10))
+    payload = json.load(f)
+    print(payload.get("leadMinutes", 5))
 PY
 )
-    exec "$0" subscribe "$ID" "$GRACE"
+    exec "$0" subscribe "$ID" "$LEAD"
     ;;
 
   status)
@@ -234,11 +275,22 @@ PY
   check)
     ID="${1-}"
     COURSE="${2-}"
-    [[ -z "$ID" || -z "$COURSE" ]] && { usage; exit 1; }
+    LECTURE_NO="${3-}"
+    if [[ "$COURSE" == "--lecture-no" ]]; then
+      LECTURE_NO="${3-}"
+      COURSE=""
+    fi
+    [[ -z "$ID" || ( -z "$COURSE" && -z "$LECTURE_NO" ) ]] && { usage; exit 1; }
 
     UDIR=$(user_dir "$ID")
-    if ! RES=$(mju ucheck attendance --course "$COURSE" --app-dir "$UDIR" --format json 2>&1); then
-      exit 0
+    if [[ -n "$LECTURE_NO" ]]; then
+      if ! RES=$(mju ucheck attendance --lecture-no "$LECTURE_NO" --app-dir "$UDIR" --format json 2>&1); then
+        exit 0
+      fi
+    else
+      if ! RES=$(mju ucheck attendance --course "$COURSE" --app-dir "$UDIR" --format json 2>&1); then
+        exit 0
+      fi
     fi
 
     CONTENT=$(ATTENDANCE_JSON="$RES" COURSE_NAME="$COURSE" python3 - <<'PY'

--- a/bin/mju-news-alert
+++ b/bin/mju-news-alert
@@ -124,8 +124,47 @@ case "$CMD" in
     UDIR=$(user_dir "$DISCORD_ID")
     mkdir -p "$UDIR"
 
-    if ! openclaw cron rm "$(job_name "$DISCORD_ID")" >/dev/null 2>&1; then
+    # 같은 name으로 cron이 누적되는 문제(#duplicate-attendance-alerts)를 막기 위해
+    # add 전에 같은 name의 cron을 확실히 제거한다. cron list로 존재 여부를 보고 있을
+    # 때만 rm을 시도(없으면 정상). list/rm이 실패하면 add를 막아 누적을 방지한다.
+    JOB="$(job_name "$DISCORD_ID")"
+    JOBS_JSON=""
+    for attempt in 1 2 3 4 5; do
+      if JOBS_JSON=$(openclaw cron list --json 2>/dev/null) && [[ -n "$JOBS_JSON" ]]; then
+        break
+      fi
+      JOBS_JSON=""
+      sleep 1
+    done
+    if [[ -z "$JOBS_JSON" ]]; then
+      echo "ERR: openclaw cron list 실패. cron 누적 위험으로 subscribe 중단." >&2
+      exit 1
+    fi
+
+    if JOB_NAME="$JOB" JOBS_JSON="$JOBS_JSON" python3 - <<'PY'
+import json, os, subprocess, sys
+job = os.environ["JOB_NAME"]
+try:
+    data = json.loads(os.environ["JOBS_JSON"])
+    jobs = data.get("jobs", []) if isinstance(data, dict) else data
+except Exception as exc:
+    print(f"ERR news subscribe: invalid cron list JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+targets = [j for j in jobs if j.get("name") == job]
+for t in targets:
+    result = subprocess.run(
+        ["openclaw", "cron", "rm", t.get("id") or t.get("name")],
+        check=False, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"ERR news subscribe: failed to rm {t.get('id') or t.get('name')}: {(result.stderr or result.stdout).strip()}", file=sys.stderr)
+        sys.exit(1)
+PY
+    then
       :
+    else
+      echo "ERR: 기존 news cron 제거 실패. 누적 방지를 위해 subscribe 중단." >&2
+      exit 1
     fi
 
     printf -v deliver_cmd 'mju-news-alert deliver %q' "$DISCORD_ID"
@@ -199,6 +238,39 @@ case "$CMD" in
     [[ -z "$DISCORD_ID" ]] && { usage; exit 1; }
     F=$(subs_file "$DISCORD_ID")
     [[ ! -f "$F" ]] && { echo "신규 공지 없음"; exit 0; }
+
+    # 같은 사용자에 대한 deliver 동시 실행 방지. cron이 어떤 이유(중복 등록, retry)로
+    # 짧은 시간 안에 두 번 발사되어도, 두 번째는 lock을 못 얻고 바로 exit 한다.
+    UDIR=$(user_dir "$DISCORD_ID")
+    mkdir -p "$UDIR"
+    LOCK_FILE="$UDIR/.news-deliver.lock"
+    exec 9>"$LOCK_FILE"
+    if ! flock -n 9; then
+      exit 0
+    fi
+
+    # lastSentAt 기반 쿨다운 — flock을 통과해도 5분 안에 이미 발송한 흔적이 있으면 skip.
+    # cron이 같은 시각에 N번 발사되더라도 첫 번째만 발송되도록 하는 안전망.
+    if FILE_PATH="$F" python3 - <<'PY'
+import json, os, sys
+from datetime import datetime, timezone
+try:
+    with open(os.environ["FILE_PATH"], encoding="utf-8") as f:
+        last = json.load(f).get("lastSentAt")
+except Exception:
+    sys.exit(1)
+if not last:
+    sys.exit(1)
+try:
+    dt = datetime.fromisoformat(last.replace("Z", "+00:00"))
+except Exception:
+    sys.exit(1)
+delta = (datetime.now(timezone.utc) - dt.astimezone(timezone.utc)).total_seconds()
+sys.exit(0 if delta < 300 else 1)
+PY
+    then
+      exit 0
+    fi
 
     SINCE=$(FILE_PATH="$F" python3 - <<'PY'
 import json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -269,7 +269,26 @@ fi
 # 이미 구독 중이면 refresh로 시간표 재스냅, 아니면 subscribe로 신규 등록.
 # 각 유저당 timetable 조회 + cron 등록이 5~7초 들 수 있어 gateway 기동을 막지 않도록
 # 백그라운드로 돌린다. 실패(시간표 미제공, SSO 만료 등)는 stderr로만 남김.
+#
+# IMPORTANT: 반드시 gateway가 ws 포트(18789)에서 응답을 시작한 뒤에 helper를 호출한다.
+# helper의 `openclaw cron list` 호출이 gateway 준비 전이면 1006으로 끊겨 silent
+# failure로 흘러가고, 그 결과 stale cron 정리가 누락되어 같은 알림 cron이 매 backfill
+# 마다 누적되는 버그가 있었다 (#duplicate-attendance-alerts).
 attendance_backfill() {
+  # gateway healthz가 200을 줄 때까지 polling. 각 iteration이 curl --max-time 1 +
+  # sleep 1 = ~2s 들고 최대 30회 시도하므로 상한은 ~60s. 그 안에 못 받으면 경고만 남
+  # 기고 그래도 진행 (학기 동안 한 번도 동작 안 하는 것보단 helper의 retry 안전망에
+  # 맡기는 게 낫다).
+  local waited=0
+  until curl -sf -o /dev/null --max-time 1 http://127.0.0.1:18789/healthz; do
+    if (( waited >= 30 )); then
+      echo "WARN entrypoint: gateway not ready after ~60s, attendance backfill proceeding anyway" >&2
+      break
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+
   shopt -s nullglob 2>/dev/null || true
   for user_dir in /data/users/*/; do
     discord_id=$(basename "$user_dir")


### PR DESCRIPTION
## Summary

운영 환경에서 일부 사용자에게 같은 출석 알림이 한 수업당 **6번**, 같은 공지 알림이 **2번** 발송되는 결함을 수정한다. 두 helper 모두 cron이 silently 누적되는 동일 root cause에서 시작됐고, 발송 단계의 멱등성 부재가 증폭기 역할을 했다.

## Root cause (실측)

- 사용자 `1151...`의 모든 출석 cron 슬롯에 같은 name의 cron이 **정확히 6개씩** (`6 × 6 슬롯 = 36`) 누적. 이 숫자는 컨테이너 entrypoint가 돈 횟수와 일치 (4/25 + 5/1×4 + 진단 시점 = 6).
- `bin/mju-attendance-alert`의 `remove_stale_crons`가 \`openclaw cron list --json 2>/dev/null || true\` + python heredoc \`2>/dev/null || true\`로 모든 실패를 silent로 흘렸다.
- entrypoint가 \`attendance_backfill &\` 백그라운드 직후 \`exec openclaw gateway\`로 진입 → backfill의 첫 cron list 호출이 **gateway ws 포트가 listen하기 전**에 들어가 \`1006 abnormal closure\`로 끊김 → silent failure → stale cron 정리 누락 → 매 backfill마다 새 generation cron만 누적.
- \`/data/users/*/\` 사전순 첫 사용자(`1151...`)가 가장 자주 race에 노출, 후순위는 그 사이 gateway가 깨어나 정상 dedupe.
- `bin/mju-news-alert`도 동일 구조의 \`cron rm\` silent failure로 같은 name cron 중복 등록 가능.
- `check`/`deliver`에 발송 이력이 없어 cron N개 발사 → DM N번 그대로 발송.

## 변경 (4 commits)

1. **fix(entrypoint): backfill 시작 전 gateway readiness 대기** — \`curl -sf http://127.0.0.1:18789/healthz\`를 1초 간격 최대 30회(~60s) 폴링. race trigger 자체 제거.
2. **fix(attendance-alert): remove_stale_crons silent failure 제거** — list 5회 retry, 끝까지 실패면 stderr + return 1. python heredoc도 모든 실패를 명시 보고. subscribe는 정리 실패 시 경고만(이미 swap됨), unsubscribe는 exit 1.
3. **fix(attendance-alert): check 단계에 atomic 멱등 marker 추가** — \`set -o noclobber; : > MARKER_FILE\` atomic create로 같은 사용자/날짜/수업 조합당 하루 1번만 발송. cron이 N개 동시 발사돼도 한 프로세스만 통과 (TOCTOU race 차단). send 실패 시 marker rollback.
4. **fix(news-alert): subscribe 멱등성 + deliver 동시 실행 방지** — subscribe의 cron rm을 list-then-rm으로 명시화 + 5회 retry. deliver에 \`flock -n\` + lastSentAt 5분 쿨다운 안전망.

## 결함 → 수정 매핑

| 결함 layer | 수정 |
|---|---|
| 등록 race trigger | commit 1 (gateway wait) |
| 등록 silent failure (attendance) | commit 2 |
| 발송 멱등성 부재 (attendance) | commit 3 |
| 등록/발송 멱등성 부재 (news) | commit 4 |

## Test plan

- [ ] CI: bash syntax 검증 (\`bash -n\` — 로컬에서 3개 파일 모두 통과 확인)
- [ ] 컨테이너 재빌드 후 부팅 시 entrypoint 로그에서 \`Started attendance alert backfill\`이 gateway ready 로그 이후에 찍히는지 확인
- [ ] 배포 직후 \`docker exec mjuclaw-agent openclaw cron list --json | jq -r '.jobs[] | select(.name | startswith(\"attend-\")) | .name' | sort | uniq -c | sort -nr | head\` — 모든 attend cron이 1회씩만 등장하는지 (1151 사용자의 36개 옛 cron이 새 \`remove_stale_crons\`로 자동 정리되어야 함)
- [ ] 같은 사용자의 같은 수업 슬롯에 cron 중복 등록 시 marker 동작 검증 (수동 시나리오)

## 운영 hot-fix 불필요

이번 패치 deploy 후 첫 컨테이너 부팅에서:
1. entrypoint가 gateway healthz 대기
2. backfill의 \`refresh\` 호출
3. subscribe가 새 generation cron 등록 + config swap
4. **새 \`remove_stale_crons\`가 retry 강화 덕에 성공** → 옛 generation의 stale cron이 keep set에 없으므로 정리

→ 사용자 1151의 누적 36개도 자동 정리. 별도 수동 정리 명령 불필요. (backup 안전망: 자동 정리가 첫 시도에 안 되면 다음 backfill에서 다시 시도.)

## Out of scope (follow-up issue 후보)

- pre-existing TZ inconsistency: \`bin/mju-attendance-alert\` check의 python \`today = datetime.now().astimezone()\`는 컨테이너 local TZ를 따른다. marker(KST)와 한 줄 내에서 일관성을 맞추려면 python 쪽도 \`TZ=Asia/Seoul\` 명시 필요. 0:00–9:00 KST에 컨테이너 TZ가 UTC면 하루 drift 가능. 이번 결함과 무관, 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)