### PR TITLE
feat: mjuclaw-router 통합 — Discord WS 입구 분리 + cron alert 우회

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,26 @@ MJU_VAULT_KEY=replace-me-with-openssl-rand-hex-32
 # 에이전트 컨테이너에 read-only로 마운트된다 (컨테이너 내부 경로: /data/assets).
 # 예: /Users/kbsoo/Codes/projects/mjuclaw/.data/assets
 STORAGE_LOCAL_ROOT=/absolute/path/to/mjuclaw-workspace/.data/assets
+
+# ── mjuclaw-router 통합 (Discord WS 입구 분리) ──────────────────
+# 봇 토큰은 mjuclaw-router가 단독으로 들고 Discord Gateway에 connect한다.
+# OpenClaw 측 discord 채널은 비활성화된다 (같은 봇 토큰 동시 connect 불가).
+#
+# router HTTP /discord/send 인증 토큰. agent의 cron alert helper가 outbound
+# DM을 router로 위임할 때 사용. 16자 이상 권장.
+#   openssl rand -hex 32
+MJUCLAW_ROUTER_TOKEN=replace-me-with-openssl-rand-hex-32
+
+# OpenClaw Gateway 인증 토큰. router가 `openclaw agent --json --token ...`
+# 으로 forward할 때 agent의 gateway에 인증한다. 양쪽 컨테이너에 동일 값.
+#   openssl rand -hex 32
+OPENCLAW_GATEWAY_TOKEN=replace-me-with-openssl-rand-hex-32
+
+# router가 agent의 OpenClaw gateway를 가리키는 WS URL. 보통 그대로.
+OPENCLAW_GATEWAY_URL=ws://mjuclaw-agent:18789
+
+# router 컨테이너 내부 HTTP endpoint (agent → router 호출용). 보통 그대로.
+MJUCLAW_ROUTER_URL=http://mjuclaw-router:3100
+
+# router 로그 레벨: trace|debug|info|warn|error|fatal
+ROUTER_LOG_LEVEL=info

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 dist/
 mju-cli/
 mju-news/
+mjuclaw-router/

--- a/bin/mju-attendance-alert
+++ b/bin/mju-attendance-alert
@@ -285,10 +285,35 @@ PY
 
     [[ -z "$CONTENT" ]] && exit 0
 
-    if ! openclaw message send --channel discord --target "user:$ID" --message "$CONTENT"; then
-      echo "ERR: failed to deliver attendance alert to $ID" >&2
+    # OpenClaw discord 채널은 비활성화되어 있고 봇 토큰은 mjuclaw-router가 단독
+    # 소유한다. 따라서 outbound DM은 router HTTP `POST /discord/send`로 위임한다.
+    ROUTER_URL="${MJUCLAW_ROUTER_URL:-http://mjuclaw-router:3100}"
+    ROUTER_TOKEN="${MJUCLAW_ROUTER_TOKEN-}"
+    if [[ -z "$ROUTER_TOKEN" ]]; then
+      echo "ERR: MJUCLAW_ROUTER_TOKEN env가 비어있어 router로 DM을 보낼 수 없습니다." >&2
       exit 1
     fi
+
+    SEND_BODY=$(DISCORD_ID="$ID" CONTENT="$CONTENT" python3 - <<'PY'
+import json, os
+print(json.dumps({"discordUserId": os.environ["DISCORD_ID"], "content": os.environ["CONTENT"]}))
+PY
+)
+
+    HTTP_OUT=$(mktemp "${TMPDIR:-/tmp}/router-send.XXXXXX")
+    HTTP_CODE=$(curl -sS -o "$HTTP_OUT" -w "%{http_code}" \
+      -X POST "$ROUTER_URL/discord/send" \
+      -H "Authorization: Bearer $ROUTER_TOKEN" \
+      -H "Content-Type: application/json" \
+      --max-time 30 \
+      --data-raw "$SEND_BODY" || echo "000")
+    if [[ "$HTTP_CODE" != "200" ]]; then
+      RESP_BODY=$(cat "$HTTP_OUT" 2>/dev/null || true)
+      rm -f "$HTTP_OUT"
+      echo "ERR: router /discord/send → HTTP $HTTP_CODE: ${RESP_BODY:-<no body>}" >&2
+      exit 1
+    fi
+    rm -f "$HTTP_OUT"
 
     printf '%s\n' "$CONTENT"
     ;;

--- a/bin/mju-news-alert
+++ b/bin/mju-news-alert
@@ -327,10 +327,35 @@ PY
       exit 0
     fi
 
-    if ! openclaw message send --channel discord --target "user:$DISCORD_ID" --message "$CONTENT"; then
-      echo "ERR: failed to deliver news alert to $DISCORD_ID" >&2
+    # OpenClaw discord 채널은 비활성화되어 있고 봇 토큰은 mjuclaw-router가 단독
+    # 소유한다. 따라서 outbound DM은 router HTTP `POST /discord/send`로 위임한다.
+    ROUTER_URL="${MJUCLAW_ROUTER_URL:-http://mjuclaw-router:3100}"
+    ROUTER_TOKEN="${MJUCLAW_ROUTER_TOKEN-}"
+    if [[ -z "$ROUTER_TOKEN" ]]; then
+      echo "ERR: MJUCLAW_ROUTER_TOKEN env가 비어있어 router로 DM을 보낼 수 없습니다." >&2
       exit 1
     fi
+
+    SEND_BODY=$(DISCORD_ID="$DISCORD_ID" CONTENT="$CONTENT" python3 - <<'PY'
+import json, os
+print(json.dumps({"discordUserId": os.environ["DISCORD_ID"], "content": os.environ["CONTENT"]}))
+PY
+)
+
+    HTTP_OUT=$(mktemp "${TMPDIR:-/tmp}/router-send.XXXXXX")
+    HTTP_CODE=$(curl -sS -o "$HTTP_OUT" -w "%{http_code}" \
+      -X POST "$ROUTER_URL/discord/send" \
+      -H "Authorization: Bearer $ROUTER_TOKEN" \
+      -H "Content-Type: application/json" \
+      --max-time 30 \
+      --data-raw "$SEND_BODY" || echo "000")
+    if [[ "$HTTP_CODE" != "200" ]]; then
+      RESP_BODY=$(cat "$HTTP_OUT" 2>/dev/null || true)
+      rm -f "$HTTP_OUT"
+      echo "ERR: router /discord/send → HTTP $HTTP_CODE: ${RESP_BODY:-<no body>}" >&2
+      exit 1
+    fi
+    rm -f "$HTTP_OUT"
 
     if ! update_last_sent_at "$F"; then
       echo "ERR: delivered news alert but failed to update lastSentAt" >&2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
+      # ── Discord ───────────────────────────────────────────────────
+      # 봇 토큰은 mjuclaw-router가 단독으로 들고 있어야 한다 (Discord Gateway는
+      # 같은 토큰의 동시 WS 연결을 허용하지 않음). entrypoint.sh 설정상 agent의
+      # OpenClaw config는 channels.discord.enabled=False 라서 실제 connect 시도는
+      # 안 하지만, 기존 schema marker(SHA256)와 호환을 위해 같은 값을 전달한다.
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN}
       - GEMINI_API_KEY=${GEMINI_API_KEY}
       - OPENCLAW_MODEL=${OPENCLAW_MODEL:-gemini-2.5-flash}
@@ -20,6 +25,12 @@ services:
       - DISCORD_USER_ID=${DISCORD_USER_ID:-415349075274104832}
       - VIEW_PORT=${VIEW_PORT:-3001}
       - VIEW_BASE_URL=${VIEW_BASE_URL:-http://localhost:3001}
+      # ── 라우터 우회 (cron alert helper가 outbound DM 보낼 때) ──────
+      # bin/mju-news-alert / bin/mju-attendance-alert 가 사용한다.
+      - MJUCLAW_ROUTER_URL=${MJUCLAW_ROUTER_URL:-http://mjuclaw-router:3100}
+      - MJUCLAW_ROUTER_TOKEN=${MJUCLAW_ROUTER_TOKEN}
+      # ── OpenClaw gateway 인증 토큰 (router가 forward 시 사용) ─────
+      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
       # ── 호스트 Postgres (mju-public-data-worker 공유 DB) ────────────
       - PGHOST=${PGHOST:-host.docker.internal}
       - PGPORT=${PGPORT:-5432}
@@ -39,14 +50,59 @@ services:
       # envelope encryption 키 (openssl rand -hex 32). 분실 시 복호화 불가.
       - MJU_VAULT_KEY=${MJU_VAULT_KEY}
     volumes:
-      # 에이전트 세션/데이터 영속화 (컨테이너 재생성해도 유지)
       - agent-data:/home/agent/.openclaw
-      # 유저별 크리덴셜 영속화 (온보딩 데이터)
       - user-data:/data/users
-      # worker가 쓴 공지 첨부/본문 이미지 원본을 on-demand로 읽기 위한 read-only 마운트.
-      # STORAGE_LOCAL_ROOT가 설정되지 않으면 docker compose가 에러를 낸다.
       - ${STORAGE_LOCAL_ROOT}:/data/assets:ro
+    depends_on:
+      router:
+        condition: service_started
+
+  # ── mjuclaw-router ────────────────────────────────────────────────
+  # Discord WS 단독 listener + 결정론적 온보딩 게이트 + cron alert 우회 HTTP.
+  # 봇 토큰을 단독으로 들고 OpenClaw 측 discord 채널은 비활성화된다.
+  # 빌드 시 mju-cli 소스를 additional_contexts로 주입한다 (setup.sh가 clone).
+  router:
+    build:
+      context: ./mjuclaw-router
+      dockerfile: Dockerfile
+      additional_contexts:
+        mju-cli: ./mju-cli
+    container_name: mjuclaw-router
+    restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN}
+      - DISCORD_GUILD_ID=${DISCORD_SERVER_ID:-1492100109997969499}
+      - USER_DATA_ROOT=/data/users
+      - OPENCLAW_GATEWAY_URL=${OPENCLAW_GATEWAY_URL:-ws://mjuclaw-agent:18789}
+      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
+      # docker-compose 내부 네트워크(trusted private)에서만 접근하므로 plaintext ws://
+      # 허용. 외부 노출 시 wss:// + 인증서로 전환할 것.
+      - OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1
+      - HTTP_PORT=3100
+      - HTTP_BIND_HOST=0.0.0.0
+      - HTTP_AUTH_TOKEN=${MJUCLAW_ROUTER_TOKEN}
+      - LOG_LEVEL=${ROUTER_LOG_LEVEL:-info}
+      - NODE_ENV=production
+      # mju-cli postgres 백엔드 (vault read/write를 router도 동일 ROLE로 수행)
+      - MJU_STORAGE=${MJU_STORAGE:-postgres}
+      - MJU_PGHOST=${MJU_PGHOST:-${PGHOST:-host.docker.internal}}
+      - MJU_PGPORT=${MJU_PGPORT:-${PGPORT:-5432}}
+      - MJU_PGDATABASE=${MJU_PGDATABASE:-${PGDATABASE:-mjuclaw}}
+      - MJU_PGUSER=${MJU_PGUSER:-mjuclaw_user_app}
+      - MJU_PGPASSWORD=${MJU_PGPASSWORD}
+      - MJU_PGSCHEMA=${MJU_PGSCHEMA:-user_data}
+      - MJU_VAULT_KEY=${MJU_VAULT_KEY}
+    volumes:
+      - user-data:/data/users
+      # router의 openclaw client state(device pairing key 등) 영속화. 이 볼륨이
+      # 없으면 컨테이너 재생성 시 새 device key가 생기고 매번 agent에서 수동
+      # 승인이 필요해진다.
+      - router-data:/home/router/.openclaw
+    # host port 매핑 없음 — compose 내부 네트워크 전용 (3100은 agent → router만)
 
 volumes:
   agent-data:
   user-data:
+  router-data:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,12 +12,30 @@ if [ -z "${GEMINI_API_KEY:-}" ]; then
   exit 1
 fi
 
+if [ -z "${MJUCLAW_ROUTER_URL:-}" ]; then
+  echo "ERR: MJUCLAW_ROUTER_URL is required (router service URL, 보통 http://mjuclaw-router:3100)" >&2
+  exit 1
+fi
+
+if [ -z "${MJUCLAW_ROUTER_TOKEN:-}" ]; then
+  echo "ERR: MJUCLAW_ROUTER_TOKEN is required (router HTTP_AUTH_TOKEN과 동일 값)" >&2
+  exit 1
+fi
+
+if [ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]; then
+  echo "ERR: OPENCLAW_GATEWAY_TOKEN is required (router가 agent의 OpenClaw gateway에" >&2
+  echo "    forward할 때 사용하는 인증 토큰. agent와 router 양쪽 env에 동일 값으로 둠. " >&2
+  echo "    예: openssl rand -hex 32)" >&2
+  exit 1
+fi
+
 MODEL="${OPENCLAW_MODEL:-gemini-2.5-flash}"
 DISCORD_SERVER_ID="${DISCORD_SERVER_ID:-1492100109997969499}"
 DISCORD_USER_ID="${DISCORD_USER_ID:-415349075274104832}"
 
 # Config 스키마 버전. 변경되면 기존 config를 백업하고 재생성한다.
-CONFIG_SCHEMA_VERSION="3"
+# v4: channels.discord.enabled=False — Discord WS 단독 소유는 mjuclaw-router로 이전.
+CONFIG_SCHEMA_VERSION="4"
 CONFIG_PATH="/home/agent/.openclaw/openclaw.json"
 VERSION_MARKER="/home/agent/.openclaw/.mjuclaw-schema-version"
 CONFIG_INPUTS_MARKER="/home/agent/.openclaw/.mjuclaw-config-inputs.json"
@@ -72,6 +90,7 @@ print(
             ),
             "discordBotTokenSha256": sha256(os.environ["DISCORD_BOT_TOKEN"]),
             "geminiApiKeySha256": sha256(os.environ["GEMINI_API_KEY"]),
+            "gatewayTokenSha256": sha256(os.environ["OPENCLAW_GATEWAY_TOKEN"]),
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -144,20 +163,12 @@ config = {
     },
     'channels': {
         'defaults': {},
+        # Discord WS는 mjuclaw-router가 단독으로 listen한다. agent 측 discord
+        # 채널은 비활성화하여 토큰 충돌(같은 봇 토큰 동시 connect 불가)을 회피한다.
+        # 토큰은 schema 호환을 위해 그대로 두지만 enabled=False라 connect 시도 안 함.
         'discord': {
-            'enabled': True,
+            'enabled': False,
             'token': os.environ['DISCORD_BOT_TOKEN'],
-            # DM open — 누구나 DM 가능 (온보딩이 실질적 방어선)
-            'dmPolicy': 'open',
-            'allowFrom': ['*'],
-            # 길드는 allowlist — MJU 서버 멤버만 사용 가능
-            'groupPolicy': 'allowlist',
-            'guilds': {
-                os.environ.get('DISCORD_SERVER_ID', '1492100109997969499'): {
-                    'requireMention': True,
-                    'users': [],  # 빈 배열 = 길드 멤버 전체 허용
-                }
-            }
         }
     },
     'gateway': {
@@ -167,7 +178,9 @@ config = {
             'allowInsecureAuth': True,
             'dangerouslyDisableDeviceAuth': True,
         },
-        'auth': {'token': secrets.token_hex(32)},
+        # router가 cross-container로 forward할 때 사용. env로 고정해야 양쪽이
+        # 같은 값을 알 수 있다. env 미설정은 위에서 fail-fast로 차단됨.
+        'auth': {'token': os.environ['OPENCLAW_GATEWAY_TOKEN']},
         'trustedProxies': ['127.0.0.1', '::1'],
     },
     'meta': {
@@ -277,6 +290,62 @@ attendance_backfill() {
 }
 attendance_backfill &
 echo "Started attendance alert backfill in background (PID $!)"
+
+# ── mjuclaw-router pairing 자동 승인 (백그라운드) ───────────────
+# router는 docker-compose 내부 네트워크에서만 접근 가능한 신뢰 클라이언트지만,
+# OpenClaw gateway는 모든 새 client에게 device pairing을 요구한다. 첫 부팅 시
+# router가 pairing 요청을 보내면 자동 승인하고, 이후엔 router의 router-data
+# volume에 device key가 영속되어 재요청이 발생하지 않는다.
+auto_approve_router_pairings() {
+  # gateway readiness 대기 (최대 60초)
+  local waited=0
+  until curl -sf -o /dev/null --max-time 1 http://127.0.0.1:18789/healthz; do
+    if (( waited >= 60 )); then
+      echo "WARN entrypoint: gateway not ready after 60s, skip pairing auto-approve" >&2
+      return
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  # 5분 동안 5초 간격으로 pending 확인 → 승인. CLI가 gateway에 붙기까지 healthz보다
+  # 더 오래 걸리는 경우가 있어 윈도우를 넉넉히 둔다. 일단 device가 paired되면
+  # router 측 router-data 볼륨에 key가 영속되어 재요청이 발생하지 않는다.
+  local rounds=0
+  while (( rounds < 60 )); do
+    local pending_json
+    pending_json=$(openclaw devices list --json 2>/dev/null || echo '{}')
+    local request_ids
+    request_ids=$(PENDING_JSON="$pending_json" python3 - <<'PY'
+import json, os
+try:
+    data = json.loads(os.environ["PENDING_JSON"])
+except Exception:
+    raise SystemExit(0)
+for entry in data.get("pending", []) or []:
+    rid = entry.get("requestId")
+    ip = entry.get("remoteIp", "")
+    # docker-compose 내부 네트워크 (172.x / 10.x 사설 대역)만 자동 승인
+    if rid and (ip.startswith("172.") or ip.startswith("10.") or ip.startswith("192.168.")):
+        print(rid)
+PY
+)
+    if [[ -n "$request_ids" ]]; then
+      while IFS= read -r rid; do
+        [[ -z "$rid" ]] && continue
+        if openclaw devices approve "$rid" --json >/dev/null 2>&1; then
+          echo "Auto-approved router pairing $rid"
+        else
+          echo "WARN entrypoint: failed to auto-approve $rid" >&2
+        fi
+      done <<< "$request_ids"
+    fi
+    sleep 5
+    rounds=$((rounds + 1))
+  done
+}
+auto_approve_router_pairings &
+echo "Started router pairing auto-approver in background (PID $!)"
 
 echo ""
 echo "  ┌─────────────────────────────────────────────┐"

--- a/setup.sh
+++ b/setup.sh
@@ -56,6 +56,9 @@ clone_or_pull mju-cli https://github.com/university-claw/mju-cli.git
 # mju-news v2.0.0+ : Reader CLI (worker DB 읽어서 JSON 제공).
 # dev 브랜치에 변경이 진행 중이면 아래 한 줄을 `git checkout dev`로 교체.
 clone_or_pull mju-news https://github.com/university-claw/mju-news.git
+# mjuclaw-router : Discord WS 입구 + 온보딩 게이트 + cron alert 우회 HTTP 서버.
+# OpenClaw 측 Discord 채널은 비활성화되며, 봇 토큰은 router가 단독 소유한다.
+clone_or_pull mjuclaw-router https://github.com/university-claw/mjuclaw-router.git
 
 # ── 3. .env 확인 ────────────────────────────────────────────────
 echo ""
@@ -76,9 +79,9 @@ echo "  ✓ .env 존재"
 
 # 필수값 체크
 missing=()
-for key in DISCORD_BOT_TOKEN GEMINI_API_KEY PGPASSWORD STORAGE_LOCAL_ROOT; do
+for key in DISCORD_BOT_TOKEN GEMINI_API_KEY PGPASSWORD STORAGE_LOCAL_ROOT MJUCLAW_ROUTER_TOKEN; do
   val=$(grep "^$key=" .env | cut -d= -f2-)
-  if [ -z "$val" ] || [[ "$val" == your_* ]] || [[ "$val" == "change-me" ]] || [[ "$val" == /absolute/* ]]; then
+  if [ -z "$val" ] || [[ "$val" == your_* ]] || [[ "$val" == "change-me" ]] || [[ "$val" == /absolute/* ]] || [[ "$val" == replace-me-* ]]; then
     missing+=("$key")
   fi
 done
@@ -97,7 +100,8 @@ echo ""
 echo "┌─────────────────────────────────────────────┐"
 echo "│  ✅ 셋업 완료                                │"
 echo "│                                             │"
-echo "│  로그 확인:   docker logs -f mjuclaw-agent   │"
+echo "│  로그 확인:   docker logs -f mjuclaw-agent  │"
+echo "│              docker logs -f mjuclaw-router  │"
 echo "│  컨테이너 진입: docker exec -it mjuclaw-agent bash │"
 echo "│  정지:       docker compose down            │"
 echo "└─────────────────────────────────────────────┘"


### PR DESCRIPTION
## Summary
- 신규 service `mjuclaw-router`(별도 레포)를 OpenClaw 앞단에 배치.
- Discord 봇 토큰의 단독 소유자를 router로 이전 (같은 토큰 동시 WS 충돌 회피).
- agent의 OpenClaw discord 채널 비활성화 (`channels.discord.enabled = False`).
- cron alert helper(`mju-news-alert`, `mju-attendance-alert`)의 outbound DM을
  router HTTP `POST /discord/send`로 위임.
- gateway.auth.token을 env 고정으로 바꿔 router가 forward 시 인증 가능하게 함.
- 첫 부팅 시 docker private 대역의 device pairing 자동 승인.

## 왜
OpenClaw plugin SDK의 dispatch 단계 hook은 modal/components 직접 발사가 막혀있어
결정론적 온보딩 게이트를 plugin에 가둘 수 없음 ([PR #23](https://github.com/university-claw/mjuclaw-setup/pull/23)에서 검증/포기).
별도 router service가 정답 layer.

## 호환성 / 마이그레이션
- `CONFIG_SCHEMA_VERSION`이 3→4로 올라가 기존 `openclaw.json`은 자동 백업
  (`*.bak.<unix>`)되고 재생성됨.
- `.env`에 새 변수 5개 필요:
  - `MJUCLAW_ROUTER_TOKEN` — `openssl rand -hex 32`
  - `OPENCLAW_GATEWAY_TOKEN` — `openssl rand -hex 32`
  - `OPENCLAW_GATEWAY_URL` (기본값 사용 OK)
  - `MJUCLAW_ROUTER_URL` (기본값 사용 OK)
  - `ROUTER_LOG_LEVEL` (기본값 사용 OK)
- 함께 머지될 router 측 PR: https://github.com/university-claw/mjuclaw-router/pull/new/feat/http-send-endpoint

## Test plan
- [x] `docker compose build` 통과 (router + agent)
- [x] `docker compose up -d` 두 컨테이너 healthy
- [x] router `/healthz`: `discordReady: true`
- [x] router → agent gateway forward 정상 (`openclaw agent --json` status=ok)
- [x] agent → router `/discord/send` 정상 (Bearer 인증 + DM 송신)
- [ ] **사용자 직접 검증**: Discord에서 봇에게 DM/멘션 → 응답 정상 (forward), 미온보딩 사용자에 modal 발사 (`mju auth forget`로 reset 후)
- [ ] cron alert 다음 발사 시점에 정상 DM 도착 (실제 시간표 보유 사용자 대상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)