### PR TITLE
feat: MVP-2 — mjuclaw-classifier 컨테이너 + router classifier env (재타겟 dev)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,19 @@ MJUCLAW_ROUTER_URL=http://mjuclaw-router:3100
 
 # router 로그 레벨: trace|debug|info|warn|error|fatal
 ROUTER_LOG_LEVEL=info
+
+# ── Intent classifier (MVP-2) ──────────────────────────────────
+# router가 사용자 메시지를 forward하기 전에 호출해 abuse 차단을 수행한다.
+# false면 classifier 서비스를 띄우지 않아도 무방 (MVP-1 동작 유지).
+CLASSIFIER_ENABLED=true
+# router → classifier 호출 URL (compose 내부 네트워크).
+CLASSIFIER_URL=http://mjuclaw-classifier:3200
+# classifier 서버의 Bearer 인증 토큰. router/classifier 양쪽 동일 값.
+#   openssl rand -hex 32
+CLASSIFIER_AUTH_TOKEN=replace-me-with-openssl-rand-hex-32
+# classifier 호출 timeout (ms). 초과 시 router는 fail-open으로 forward 진행.
+CLASSIFIER_TIMEOUT_MS=2500
+# abuse override 임계값 (낮을수록 recall↑ precision↓).
+CLASSIFIER_ABUSE_THRESHOLD=0.25
+# classifier 로그 레벨: DEBUG|INFO|WARNING|ERROR
+CLASSIFIER_LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 mju-cli/
 mju-news/
 mjuclaw-router/
+intent-classifier/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,12 @@ services:
       - HTTP_AUTH_TOKEN=${MJUCLAW_ROUTER_TOKEN}
       - LOG_LEVEL=${ROUTER_LOG_LEVEL:-info}
       - NODE_ENV=production
+      # ── Intent classifier (MVP-2) ──────────────────────────────
+      # CLASSIFIER_ENABLED=false면 classifier 호출 없이 forward만 (MVP-1 동작).
+      - CLASSIFIER_ENABLED=${CLASSIFIER_ENABLED:-true}
+      - CLASSIFIER_URL=${CLASSIFIER_URL:-http://mjuclaw-classifier:3200}
+      - CLASSIFIER_AUTH_TOKEN=${CLASSIFIER_AUTH_TOKEN}
+      - CLASSIFIER_TIMEOUT_MS=${CLASSIFIER_TIMEOUT_MS:-2500}
       # mju-cli postgres 백엔드 (vault read/write를 router도 동일 ROLE로 수행)
       - MJU_STORAGE=${MJU_STORAGE:-postgres}
       - MJU_PGHOST=${MJU_PGHOST:-${PGHOST:-host.docker.internal}}
@@ -101,6 +107,24 @@ services:
       # 승인이 필요해진다.
       - router-data:/home/router/.openclaw
     # host port 매핑 없음 — compose 내부 네트워크 전용 (3100은 agent → router만)
+
+  # ── mjuclaw-classifier (MVP-2 intent gate) ───────────────────────
+  # KcELECTRA-base 15-class 한국어 의도 분류 FastAPI. router가 사용자 메시지를
+  # forward하기 전에 호출하여 abuse 차단 + (향후) service 라우팅 분기.
+  # 모델 가중치(~500MB)가 이미지에 포함되므로 첫 빌드는 다소 무겁다.
+  classifier:
+    build:
+      context: ./intent-classifier
+      dockerfile: serving/Dockerfile
+    container_name: mjuclaw-classifier
+    restart: unless-stopped
+    environment:
+      - MODEL_DIR=/opt/intent-classifier/model
+      - ABUSE_THRESHOLD=${CLASSIFIER_ABUSE_THRESHOLD:-0.25}
+      - CLASSIFIER_AUTH_TOKEN=${CLASSIFIER_AUTH_TOKEN}
+      - LOG_LEVEL=${CLASSIFIER_LOG_LEVEL:-INFO}
+      - PORT=3200
+    # host port 매핑 없음 — router → classifier 내부 네트워크 전용
 
 volumes:
   agent-data:

--- a/setup.sh
+++ b/setup.sh
@@ -60,6 +60,22 @@ clone_or_pull mju-news https://github.com/university-claw/mju-news.git
 # OpenClaw 측 Discord 채널은 비활성화되며, 봇 토큰은 router가 단독 소유한다.
 clone_or_pull mjuclaw-router https://github.com/university-claw/mjuclaw-router.git
 
+# intent-classifier : KcELECTRA-base 15-class 한국어 의도 분류 모델 + serving.
+# 현재 git 레포가 아니라 워크스페이스 로컬 디렉토리이므로 sibling(`../intent-classifier`)
+# 에서 복사한다. 향후 별도 레포로 분리되면 위 clone_or_pull 패턴으로 대체.
+if [ ! -d intent-classifier/model ]; then
+  if [ -d ../intent-classifier/model ]; then
+    echo "  → intent-classifier 복사 (sibling → setup/)..."
+    cp -r ../intent-classifier ./intent-classifier
+  else
+    echo "  ⚠ intent-classifier 디렉토리를 찾지 못함." >&2
+    echo "    워크스페이스 루트(../intent-classifier)에 model/serving이 있어야 합니다." >&2
+    echo "    classifier 서비스 없이 진행하려면 .env의 CLASSIFIER_ENABLED=false." >&2
+  fi
+else
+  echo "  ✓ intent-classifier 이미 있음"
+fi
+
 # ── 3. .env 확인 ────────────────────────────────────────────────
 echo ""
 echo "[3/4] 환경변수 파일 확인..."


### PR DESCRIPTION
이전 PR #26은 base 브랜치(feat/router-integration)가 삭제되며 자동 close됨. 동일 브랜치를 dev로 rebase + 재타겟.

## 포함 commits
- MVP-2 classifier 컨테이너 (compose, setup.sh, .env, .gitignore) (7dcb106)

## 이전 논의
- 원본 PR: https://github.com/university-claw/mjuclaw-setup/pull/26
- mjuclaw-router 측 PR: https://github.com/university-claw/mjuclaw-router/pull/3