### PR TITLE
fix(attendance-alert): UCheck 성공 후 marker 생성 (재타겟 dev — 사용자 검토 필요)

### DIFF
--- a/bin/mju-attendance-alert
+++ b/bin/mju-attendance-alert
@@ -270,10 +270,11 @@ PY
     fi
 
     mv "$CONFIG_TMP" "$CONFIG_PATH"
-    # config는 swap 됐고 새 cron도 등록 완료. stale 정리가 실패해도 subscribe 자체는
-    # 성공이지만, 옛 cron이 남아 같은 알림이 N번 갈 수 있으므로 stderr로 명확히 경고.
+    # config는 swap 됐고 새 cron도 등록 완료. 그래도 stale 정리 실패를 성공으로
+    # 숨기면 옛 cron 누적을 놓치므로 non-zero로 노출한다.
     if ! remove_stale_crons "$ID" "$CONFIG_PATH"; then
-      echo "WARN: stale cron 정리 실패. 다음 subscribe 호출 시 다시 시도됩니다." >&2
+      echo "ERR: stale cron 정리 실패. subscribe/refresh 재시도 필요." >&2
+      exit 1
     fi
     ;;
 
@@ -328,41 +329,34 @@ PY
 
     UDIR=$(user_dir "$ID")
 
-    # 멱등 marker — 같은 사용자/날짜/수업 조합으로는 하루 한 번만 발송. cron이 어떤
-    # 이유(중복 등록, 재시도)로 두 번 이상 발사되어도 두 번째부터는 여기서 일찍 종료.
-    # cron이 Asia/Seoul로 발사되므로 marker 키도 KST 기준 날짜로 통일.
-    #
-    # 같은 슬롯에 cron이 6개 등록된 경우 OpenClaw가 같은 분에 6개를 동시 발사할 수
-    # 있다. 단순한 `[[ -e ]] + : >` 패턴은 6개가 모두 존재 검사를 통과한 뒤 모두
-    # 파일을 쓰는 TOCTOU race가 있어 실제로는 막지 못한다. `set -o noclobber` + `>`로
-    # 파일 생성 자체를 atomic lock으로 사용해 한 프로세스만 통과시킨다.
-    TODAY=$(TZ=Asia/Seoul date +%F)
-    if [[ -n "$LECTURE_NO" ]]; then
-      MARKER_KEY="$LECTURE_NO"
-    else
-      # course title은 다국어/특수문자 가능 — 파일명에 안전한 형태로 sanitize.
-      MARKER_KEY=$(printf '%s' "$COURSE" | tr -c '[:alnum:]가-힣' '_' | cut -c1-60)
-      [[ -z "$MARKER_KEY" ]] && MARKER_KEY="course"
-    fi
-    MARKER_DIR="$UDIR/.alert-sent"
-    MARKER_FILE="$MARKER_DIR/attendance-$TODAY-$MARKER_KEY.flag"
-    mkdir -p "$MARKER_DIR"
-    if ! (set -o noclobber; : > "$MARKER_FILE") 2>/dev/null; then
-      # 이미 다른 프로세스가 marker를 잡은 상태 — 중복 발송 방지를 위해 즉시 종료.
-      exit 0
+    QUERY_OK=0
+    QUERY_ERR=""
+    for attempt in 1 2 3; do
+      if [[ -n "$LECTURE_NO" ]]; then
+        if RES=$(mju ucheck attendance --lecture-no "$LECTURE_NO" --app-dir "$UDIR" --format json 2>&1); then
+          QUERY_OK=1
+          break
+        fi
+      else
+        if RES=$(mju ucheck attendance --course "$COURSE" --app-dir "$UDIR" --format json 2>&1); then
+          QUERY_OK=1
+          break
+        fi
+      fi
+      QUERY_ERR="$RES"
+      [[ "$attempt" -lt 3 ]] && sleep 2
+    done
+
+    if [[ "$QUERY_OK" != "1" ]]; then
+      if [[ -n "$LECTURE_NO" ]]; then
+        echo "ERR: UCheck attendance query failed for $ID lecture_no=$LECTURE_NO after 3 attempts: ${QUERY_ERR:-<no output>}" >&2
+      else
+        echo "ERR: UCheck attendance query failed for $ID course=$COURSE after 3 attempts: ${QUERY_ERR:-<no output>}" >&2
+      fi
+      exit 1
     fi
 
-    if [[ -n "$LECTURE_NO" ]]; then
-      if ! RES=$(mju ucheck attendance --lecture-no "$LECTURE_NO" --app-dir "$UDIR" --format json 2>&1); then
-        exit 0
-      fi
-    else
-      if ! RES=$(mju ucheck attendance --course "$COURSE" --app-dir "$UDIR" --format json 2>&1); then
-        exit 0
-      fi
-    fi
-
-    CONTENT=$(ATTENDANCE_JSON="$RES" COURSE_NAME="$COURSE" python3 - <<'PY'
+    if ! CONTENT=$(TZ=Asia/Seoul ATTENDANCE_JSON="$RES" COURSE_NAME="$COURSE" python3 - <<'PY'
 import json
 import os
 import sys
@@ -370,8 +364,9 @@ from datetime import datetime
 
 try:
     data = json.loads(os.environ["ATTENDANCE_JSON"])
-except Exception:
-    sys.exit(0)
+except Exception as exc:
+    print(f"ERR: invalid UCheck attendance JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
 
 today = datetime.now().astimezone().strftime("%Y-%m-%d")
 sessions = data.get("sessions", [])
@@ -402,12 +397,30 @@ lines.extend([
 ])
 print("\n".join(lines))
 PY
-)
+    ); then
+      exit 1
+    fi
 
     if [[ -z "$CONTENT" ]]; then
-      # 발송할 본문이 없는 경우(오늘 세션 없음 / 이미 출석 체크됨)에는 marker가 의미 없음.
-      # 다만 marker는 이미 atomic create로 잡혔으니, 다음 호출이 재시도하도록 풀어둔다.
-      rm -f "$MARKER_FILE"
+      exit 0
+    fi
+
+    # 멱등 marker — 실제 발송 대상임을 확인한 뒤에만 생성한다. UCheck 조회 실패나
+    # JSON 파싱 실패가 "오늘 발송 완료"로 굳지 않도록 marker를 조회 앞에 두지 않는다.
+    # cron이 Asia/Seoul로 발사되므로 marker 키도 KST 기준 날짜로 통일.
+    TODAY=$(TZ=Asia/Seoul date +%F)
+    if [[ -n "$LECTURE_NO" ]]; then
+      MARKER_KEY="$LECTURE_NO"
+    else
+      # course title은 다국어/특수문자 가능 — 파일명에 안전한 형태로 sanitize.
+      MARKER_KEY=$(printf '%s' "$COURSE" | tr -c '[:alnum:]가-힣' '_' | cut -c1-60)
+      [[ -z "$MARKER_KEY" ]] && MARKER_KEY="course"
+    fi
+    MARKER_DIR="$UDIR/.alert-sent"
+    MARKER_FILE="$MARKER_DIR/attendance-$TODAY-$MARKER_KEY.flag"
+    mkdir -p "$MARKER_DIR"
+    if ! (set -o noclobber; : > "$MARKER_FILE") 2>/dev/null; then
+      # 이미 다른 프로세스가 marker를 잡은 상태 — 중복 발송 방지를 위해 즉시 종료.
       exit 0
     fi
 


### PR DESCRIPTION
이전 PR #24는 base 브랜치(fix/duplicate-attendance-alerts)가 삭제되며 자동 close됨. dev에 rebase 후 재타겟.

⚠️ **사용자 검토 권장 — 이미 머지된 #19 의 디자인과 직접적으로 다른 접근**

## 디자인 차이

| | dev (PR #19 머지본) | 이 PR (#24) |
|---|---|---|
| Marker 생성 시점 | UCheck **전** atomic create | UCheck **성공 후** create |
| 동시 cron 발사 시 | atomic create로 한 프로세스만 통과 (race 방지) | UCheck N번 호출 후 marker로 후속 차단 |
| UCheck 실패 시 | marker rollback | marker 자체가 안 만들어짐 |
| stale cron 정리 실패 | WARN + 계속 | **ERR + exit 1** (#24가 더 strict) |
| UCheck retry | 없음 | **3회 retry** |

## 머지 시 고려사항
- 한 번에 동시 발사된 cron N개가 있으면 UCheck를 N번 호출하게 됨 (현재 dev 디자인은 1번만).
- 대신 UCheck retry 보강은 가치 있음.
- ⚠ 두 접근의 합치본을 만들거나, 한 쪽 선택 후 다른 부분만 cherry-pick할지 사용자가 결정.

원본 PR: https://github.com/university-claw/mjuclaw-setup/pull/24