### PR TITLE
fix(attendance-alert): UCheck 호출 전 lightweight marker peek 추가 (#28 보완)

### DIFF
--- a/bin/mju-attendance-alert
+++ b/bin/mju-attendance-alert
@@ -329,6 +329,23 @@ PY
 
     UDIR=$(user_dir "$ID")
 
+    # Pre-check: marker가 이미 존재하면 (오늘 이 수업으로 이미 발송 완료) UCheck 호출
+    # 자체를 건너뛴다. stale cron 6개가 같은 분에 발사되어도 UCheck API를 6×3=18회
+    # 호출하지 않기 위함. lock 아닌 단순 존재 검사여서 첫 발사~marker create 사이의
+    # race window는 atomic create 단계가 잡는다 (#28 의 marker semantic 유지).
+    TODAY=$(TZ=Asia/Seoul date +%F)
+    if [[ -n "$LECTURE_NO" ]]; then
+      MARKER_KEY="$LECTURE_NO"
+    else
+      MARKER_KEY=$(printf '%s' "$COURSE" | tr -c '[:alnum:]가-힣' '_' | cut -c1-60)
+      [[ -z "$MARKER_KEY" ]] && MARKER_KEY="course"
+    fi
+    MARKER_DIR="$UDIR/.alert-sent"
+    MARKER_FILE="$MARKER_DIR/attendance-$TODAY-$MARKER_KEY.flag"
+    if [[ -e "$MARKER_FILE" ]]; then
+      exit 0
+    fi
+
     QUERY_OK=0
     QUERY_ERR=""
     for attempt in 1 2 3; do
@@ -405,19 +422,10 @@ PY
       exit 0
     fi
 
-    # 멱등 marker — 실제 발송 대상임을 확인한 뒤에만 생성한다. UCheck 조회 실패나
-    # JSON 파싱 실패가 "오늘 발송 완료"로 굳지 않도록 marker를 조회 앞에 두지 않는다.
-    # cron이 Asia/Seoul로 발사되므로 marker 키도 KST 기준 날짜로 통일.
-    TODAY=$(TZ=Asia/Seoul date +%F)
-    if [[ -n "$LECTURE_NO" ]]; then
-      MARKER_KEY="$LECTURE_NO"
-    else
-      # course title은 다국어/특수문자 가능 — 파일명에 안전한 형태로 sanitize.
-      MARKER_KEY=$(printf '%s' "$COURSE" | tr -c '[:alnum:]가-힣' '_' | cut -c1-60)
-      [[ -z "$MARKER_KEY" ]] && MARKER_KEY="course"
-    fi
-    MARKER_DIR="$UDIR/.alert-sent"
-    MARKER_FILE="$MARKER_DIR/attendance-$TODAY-$MARKER_KEY.flag"
+    # 멱등 marker atomic lock — 실제 발송 대상임을 확인한 뒤 송신 직전에 잠근다.
+    # MARKER_FILE 경로는 위 pre-check에서 이미 계산됨 (중복 계산 제거).
+    # UCheck 조회 실패나 JSON 파싱 실패가 "오늘 발송 완료"로 굳지 않도록 marker는
+    # 조회 앞이 아니라 여기(CONTENT 확정 이후)에서 잡는다 — #28 의 marker semantic.
     mkdir -p "$MARKER_DIR"
     if ! (set -o noclobber; : > "$MARKER_FILE") 2>/dev/null; then
       # 이미 다른 프로세스가 marker를 잡은 상태 — 중복 발송 방지를 위해 즉시 종료.


### PR DESCRIPTION
## Summary
[#28 머지](https://github.com/university-claw/mjuclaw-setup/pull/28) 직후 보완.

stale cron N개가 같은 분에 동시 발사될 때 모두 UCheck를 호출하면 명지대 API에 N×3회(retry 포함) 부하가 가는 약점이 있었다. marker가 송신 직전에만 lock되기 때문. peek 한 줄로 첫 발사가 marker 만든 뒤 후속 발사들은 UCheck 자체를 건너뛰게 한다.

## 변경
- `MARKER_FILE` 경로 계산을 UCheck 호출 위로 이동.
- `[[ -e \$MARKER_FILE ]] && exit 0` 빠른 존재 검사 추가.
- 송신 직전 atomic create는 그대로 — race-safe lock 역할 유지 (#28 의 marker semantic 보존).

## 효과
| 시나리오 | #28 단독 | #28 + 본 PR |
|---|---|---|
| stale 0개 (평소) | UCheck 1회 | UCheck 1회 (peek 한 번 더) |
| stale 6개 (비정상) | UCheck **18회** (6×3 retry) | UCheck **3회** (첫 발사만, 나머지 5개는 peek로 종료) |
| DM 중복 | 0 (atomic lock) | 0 (atomic lock 동일) |

## Test plan
- [x] bash syntax check 통과
- [ ] 컨테이너 재빌드 후 attendance cron 정상 발사 확인