### PR TITLE
feat(view): MSI 수강점수 웹뷰 및 현재 학기 성적 라우팅 추가

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+bin/* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 dist/
 mju-cli/
 mju-news/
+.tmp/
+output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # 공개 정보(공지/학식) 데이터는 호스트의 Postgres(mju-public-data-worker 공유)에서 읽는다.
 #
 # 사전 준비 (./setup.sh로 자동화 가능):
-#   git clone https://github.com/university-claw/mju-cli.git
+#   git clone --branch msi-course-scores https://github.com/university-claw/mju-cli.git
 #   git clone https://github.com/university-claw/mju-news.git   # v2.0.0+: Reader CLI
 #   # 호스트에 Postgres 설치 + mju-public-data-worker를 한 번 이상 실행
 #

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cd mjuclaw-setup
 
 ```bash
 # 도구 레포 clone (gitignore 됨)
-git clone https://github.com/university-claw/mju-cli.git
+git clone --branch msi-course-scores https://github.com/university-claw/mju-cli.git
 git clone https://github.com/university-claw/mju-news.git
 
 # 환경변수 설정
@@ -182,7 +182,7 @@ Docker volume으로 컨테이너를 재생성해도 유지됩니다.
 | `mju-shared` | 공통 인증/출력 규칙 (Discord User ID 기반 app-dir) |
 | `mju-onboarding` | 로그인 흐름 |
 | `mju-lms` / `mju-lms-action-items` | LMS 강의/공지/과제 |
-| `mju-msi` | 시간표/성적/졸업요건 |
+| `mju-msi` | 시간표/성적/수강점수/졸업요건 |
 | `mju-ucheck` | 출석 조회 |
 | `mju-library` / `mju-library-seat-*` / `mju-library-my-*` | 도서관 |
 | `recipe-mju-*` | 복합 레시피 (일일 요약 등) |

--- a/REPORT.md
+++ b/REPORT.md
@@ -117,7 +117,8 @@ flowchart TB
 | `lms +action-items` | 미제출 과제 + 마감임박 + 안읽은 공지 + 미수강 온라인 한 번에 |
 | `lms +unsubmitted` / `+unread-notices` / `+incomplete-online` | 각 항목별 필터링 |
 | `msi timetable` | 시간표 |
-| `msi current-grades` / `grade-history` | 성적 |
+| `msi course-scores` | 현재 학기 수강점수 |
+| `msi grade-history` | 지난 학기/전체 성적 이력 |
 | `msi graduation` | 졸업요건 |
 | `ucheck attendance` / `lectures list` | 과목별 출석 현황 |
 | `library ...` | 도서관 좌석/스터디룸 예약 |
@@ -200,6 +201,7 @@ mjuclaw-setup/
 │   └── types.ts
 ├── skills/                 # 에이전트 전용 skill 오버라이드
 │   ├── mju-shared/SKILL.md  # Discord User ID 기반 --app-dir 규칙
+│   ├── mju-msi/SKILL.md     # 현재 학기 성적 의도를 course-scores로 라우팅
 │   └── mju-onboarding/SKILL.md
 └── workspace/              # OpenClaw 에이전트 시스템 프롬프트
     ├── BOOTSTRAP.md         # 핵심 행동 규칙
@@ -492,7 +494,7 @@ docker exec mjuclaw-agent cat /home/agent/.openclaw/view-store.json | jq 'length
 
 - 등록 유저: 4명
 - 활성 cron 수: 7개 (공용 1 + 출석 6)
-- 지원 dataType 렌더러: 11종
+- 지원 dataType 렌더러: 12종
 - 총 라이브 테스트 시간: ~3일
 - 최근 해결 이슈: view-renderer 필드 mismatch, AI 요약 빈 카드, view-store 휘발성
 

--- a/bin/mju
+++ b/bin/mju
@@ -7,7 +7,8 @@
 #   lms +unsubmitted   → unsubmitted
 #   lms +unread-notices → unread-notices
 #   msi timetable      → timetable
-#   msi grades         → grades
+#   msi course-scores  → course-scores
+#   msi grade-history  → grade-history
 #   msi graduation     → graduation
 #   ucheck ...         → attendance
 #   그 외              → generic
@@ -16,7 +17,9 @@
 
 set -euo pipefail
 
-REAL_MJU="/opt/mju-cli/dist/main.js"
+REAL_MJU="${MJU_REAL_BIN:-/opt/mju-cli/dist/main.js}"
+NODE_BIN="${MJU_NODE_BIN:-node}"
+CURL_BIN="${MJU_CURL_BIN:-curl}"
 VIEW_API="${VIEW_API_URL:-http://localhost:3001/api/view}"
 
 has_app_dir() {
@@ -58,24 +61,11 @@ detect_datatype() {
     *"lms +unread-notices"*) echo "unread-notices" ;;
     *"lms +digest"*) echo "action-items" ;;
     *"msi timetable"*) echo "timetable" ;;
+    *"msi course-scores"*) echo "course-scores" ;;
     *"msi grade-history"*) echo "grade-history" ;;
-    *"msi current-grades"*) echo "grades" ;;
-    *"msi grades"*) echo "grades" ;;
     *"msi graduation"*) echo "graduation" ;;
     *"ucheck"*) echo "attendance" ;;
-    *"ucheck attendance"*) echo "attendance" ;;
     *) echo "" ;;
-  esac
-}
-
-# 조회성 커맨드 (읽기 only)만 web view 생성 — auth/config 등은 제외
-should_view() {
-  local args="$*"
-  case "$args" in
-    *" +"*) return 0 ;;
-    *"timetable"*|*"grade-history"*|*"grades"*|*"graduation"*|*"attendance"*) return 0 ;;
-    *"auth "*|*"config "*|*"doctor"*|*"skills"*) return 1 ;;
-    *) return 1 ;;
   esac
 }
 
@@ -85,7 +75,7 @@ title_for_datatype() {
     "unsubmitted") echo "미제출 과제" ;;
     "unread-notices") echo "안 읽은 공지" ;;
     "timetable") echo "시간표" ;;
-    "grades") echo "성적" ;;
+    "course-scores") echo "수강점수" ;;
     "grade-history") echo "학기별 성적" ;;
     "graduation") echo "졸업요건" ;;
     "attendance") echo "출석" ;;
@@ -102,7 +92,7 @@ STDERR_FILE=$(mktemp "${TMPDIR:-/tmp}/mju-stderr.XXXXXX")
 trap 'rm -f "$STDERR_FILE"' EXIT
 
 set +e
-STDOUT=$(node "$REAL_MJU" "$@" 2>"$STDERR_FILE")
+STDOUT=$("$NODE_BIN" "$REAL_MJU" "$@" 2>"$STDERR_FILE")
 EXIT=$?
 set -e
 
@@ -112,8 +102,14 @@ if [[ -n "$STDERR" ]]; then
   printf '%s\n' "$STDERR" >&2
 fi
 
-# exit 실패이거나 view 대상 아니면 그냥 pass-through
-if [[ $EXIT -ne 0 ]] || ! should_view "$@"; then
+# exit 실패이면 그냥 pass-through
+if [[ $EXIT -ne 0 ]]; then
+  printf '%s\n' "$STDOUT"
+  exit "$EXIT"
+fi
+
+DATA_TYPE=$(detect_datatype "$@")
+if [[ -z "$DATA_TYPE" ]]; then
   printf '%s\n' "$STDOUT"
   exit "$EXIT"
 fi
@@ -126,13 +122,6 @@ case "$*" in
     exit "$EXIT"
     ;;
 esac
-
-DATA_TYPE=$(detect_datatype "$@")
-if [[ -z "$DATA_TYPE" ]]; then
-  printf '%s\n' "$STDOUT"
-  exit "$EXIT"
-fi
-
 TITLE=$(title_for_datatype "$DATA_TYPE")
 
 REQUEST_BODY=$(RAW_STDOUT="$STDOUT" DATA_TYPE="$DATA_TYPE" TITLE="$TITLE" python3 - <<'PY'
@@ -156,7 +145,7 @@ PY
 )
 
 set +e
-VIEW_RESP=$(curl -s --max-time 3 -X POST "$VIEW_API" \
+VIEW_RESP=$("$CURL_BIN" -s --max-time 3 -X POST "$VIEW_API" \
   -H "Content-Type: application/json" \
   -d "$REQUEST_BODY" 2>/dev/null)
 CURL_EXIT=$?

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,9 @@
 set -e
 cd "$(dirname "$0")"
 
+MJU_CLI_BRANCH="${MJU_CLI_BRANCH:-msi-course-scores}"
+MJU_NEWS_BRANCH="${MJU_NEWS_BRANCH:-}"
+
 echo "┌─────────────────────────────────────────────┐"
 echo "│  MJUClaw Agent — 자동 셋업                  │"
 echo "└─────────────────────────────────────────────┘"
@@ -43,19 +46,39 @@ echo "[2/4] 도구 레포 준비..."
 clone_or_pull() {
   local DIR="$1"
   local REPO="$2"
+  local BRANCH="${3:-}"
   if [ -d "$DIR/.git" ]; then
-    echo "  → $DIR 이미 있음, pull 중..."
-    (cd "$DIR" && git pull --ff-only) || echo "  ⚠ $DIR pull 실패 (수동 해결 필요)"
+    if [ -n "$BRANCH" ]; then
+      echo "  → $DIR 이미 있음, origin/$BRANCH 동기화 중..."
+      (
+        cd "$DIR"
+        git fetch origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+        if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+          git checkout "$BRANCH"
+        else
+          git checkout -b "$BRANCH" "origin/$BRANCH"
+        fi
+        git pull --ff-only origin "$BRANCH"
+      )
+    else
+      echo "  → $DIR 이미 있음, pull 중..."
+      (cd "$DIR" && git pull --ff-only)
+    fi
   else
-    echo "  → $DIR clone 중..."
-    git clone "$REPO" "$DIR"
+    if [ -n "$BRANCH" ]; then
+      echo "  → $DIR clone 중... ($BRANCH)"
+      git clone --branch "$BRANCH" "$REPO" "$DIR"
+    else
+      echo "  → $DIR clone 중..."
+      git clone "$REPO" "$DIR"
+    fi
   fi
 }
 
-clone_or_pull mju-cli https://github.com/university-claw/mju-cli.git
+clone_or_pull mju-cli https://github.com/university-claw/mju-cli.git "$MJU_CLI_BRANCH"
 # mju-news v2.0.0+ : Reader CLI (worker DB 읽어서 JSON 제공).
 # dev 브랜치에 변경이 진행 중이면 아래 한 줄을 `git checkout dev`로 교체.
-clone_or_pull mju-news https://github.com/university-claw/mju-news.git
+clone_or_pull mju-news https://github.com/university-claw/mju-news.git "$MJU_NEWS_BRANCH"
 
 # ── 3. .env 확인 ────────────────────────────────────────────────
 echo ""

--- a/skills/mju-msi/SKILL.md
+++ b/skills/mju-msi/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: mju-msi
+version: 1.0.1
+description: "시간표, 현재 학기 수강점수, 성적 이력, 졸업요건을 조회하는 MSI skill."
+metadata:
+  openclaw:
+    category: "service"
+    domain: "education"
+    requires:
+      bins: ["mju"]
+      skills: ["mju-shared"]
+---
+
+# MJU MSI
+
+모든 명령은 `--app-dir /data/users/<DISCORD_USER_ID> --format json` 플래그와 함께 실행됩니다.
+
+## 자주 쓰는 명령
+- 시간표 조회: `mju --app-dir /data/users/<DISCORD_USER_ID> --format json msi timetable`
+  - 선택 옵션: `--year <연도> --term-code <학기코드>`
+- 현재 학기 성적/점수: `mju --app-dir /data/users/<DISCORD_USER_ID> --format json msi course-scores`
+  - "이번 학기 성적", "현재 성적", "중간고사 점수", "기말고사 점수", "수강점수", "학기 중 점수" 요청에 사용합니다.
+  - 선택 옵션: `--year <연도> --term-code <학기코드>`
+- 전체 성적 이력: `mju --app-dir /data/users/<DISCORD_USER_ID> --format json msi grade-history`
+  - "지난 학기 성적", "성적 이력", "누적 평점" 요청에 사용합니다.
+- 졸업 요건: `mju --app-dir /data/users/<DISCORD_USER_ID> --format json msi graduation`
+
+현재 학기 성적 관련 의도는 최종 학점/등급이 아직 없을 수 있으므로 모두 `msi course-scores`로 처리하세요. 기존 확정등급 조회 명령은 사용하지 않습니다.

--- a/skills/mju-onboarding/SKILL.md
+++ b/skills/mju-onboarding/SKILL.md
@@ -83,7 +83,7 @@ PW_END
 예시:
 ```bash
 mju lms courses list --app-dir /data/users/{DISCORD_USER_ID} --format json
-mju msi grades --app-dir /data/users/{DISCORD_USER_ID} --format json
+mju msi course-scores --app-dir /data/users/{DISCORD_USER_ID} --format json
 ```
 
 ## 로그아웃

--- a/src/view-renderer.ts
+++ b/src/view-renderer.ts
@@ -17,6 +17,7 @@ import type { ViewEntry } from "./types";
 
 const DATA_TYPE_META: Record<string, { kicker: string; detail: string }> = {
   timetable: { kicker: "TIMETABLE", detail: "시간표" },
+  "course-scores": { kicker: "COURSE SCORES", detail: "수강점수" },
   grades: { kicker: "GRADES", detail: "성적" },
   "grade-history": { kicker: "GRADE HISTORY", detail: "학기별 성적" },
   graduation: { kicker: "GRADUATION", detail: "졸업요건" },
@@ -41,7 +42,7 @@ function metaFor(dataType: string): { kicker: string; detail: string } {
 export function renderViewHtml(entry: ViewEntry): string {
   const dataHtml = renderData(entry.dataType, entry.rawData);
   let briefingHtml = "";
-  if (entry.dataType !== "timetable" && entry.dataType !== "grades" && entry.dataType !== "grade-history" && entry.dataType !== "graduation" && entry.dataType !== "action-items" && entry.dataType !== "unsubmitted" && entry.dataType !== "unread-notices" && entry.dataType !== "attendance" && entry.dataType !== "news" && entry.dataType !== "news-detail" && entry.dataType !== "cafeteria") {
+  if (entry.dataType !== "timetable" && entry.dataType !== "course-scores" && entry.dataType !== "grades" && entry.dataType !== "grade-history" && entry.dataType !== "graduation" && entry.dataType !== "action-items" && entry.dataType !== "unsubmitted" && entry.dataType !== "unread-notices" && entry.dataType !== "attendance" && entry.dataType !== "news" && entry.dataType !== "news-detail" && entry.dataType !== "cafeteria") {
     const aiResponseEffective = entry.aiResponse?.trim()
       ? entry.aiResponse
       : generateFallbackSummary(entry.dataType, entry.rawData);
@@ -961,6 +962,147 @@ body {
   font-variant-numeric: tabular-nums; white-space: nowrap;
 }
 
+/* Course scores */
+.course-score-detail-section {
+  padding-top: 22px;
+}
+.course-score-summary {
+  margin-top: 22px;
+  padding: 18px 16px 16px;
+  border: 1px solid var(--rule-strong);
+  border-radius: var(--radius-md);
+  background: linear-gradient(180deg, var(--bg-alt), var(--bg));
+}
+.course-score-summary-label {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 8px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 850;
+}
+.course-score-summary-main {
+  margin-top: 11px;
+  color: var(--ink);
+  font-size: 20px;
+  line-height: 1.25;
+  font-weight: 850;
+  word-break: keep-all;
+}
+.course-score-summary-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 14px;
+}
+.course-score-summary-stat {
+  min-width: 0;
+  min-height: 56px;
+  padding: 10px 11px;
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+.course-score-summary-stat strong {
+  display: block;
+  color: var(--ink);
+  font-size: 17px;
+  line-height: 1;
+  font-weight: 850;
+  font-variant-numeric: tabular-nums;
+}
+.course-score-summary-stat span {
+  display: block;
+  margin-top: 6px;
+  color: var(--ink-3);
+  font-size: 10.5px;
+  line-height: 1.25;
+  font-weight: 750;
+  word-break: keep-all;
+}
+.course-score-course-list {
+  margin-top: 18px;
+  border-top: 1px solid var(--rule-strong);
+}
+.course-score-course {
+  margin-top: 16px;
+  padding: 16px;
+  border-top: 1px solid var(--rule);
+  border-radius: var(--radius-md);
+  background: var(--bg-alt);
+}
+.course-score-course:first-child { border-top: none; }
+.course-score-course-head {
+  margin-bottom: 14px;
+  padding-bottom: 11px;
+  border-bottom: 1px solid var(--rule-strong);
+}
+.course-score-course-title {
+  min-width: 0;
+  color: var(--ink); font-size: 16px; line-height: 1.3; font-weight: 850;
+  word-break: keep-all;
+}
+.course-score-row {
+  padding: 13px 0;
+  border-top: 1px solid var(--rule);
+}
+.course-score-row:first-of-type { border-top: none; padding-top: 0; }
+.course-score-row-head {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  gap: 12px;
+}
+.course-score-title {
+  color: var(--ink); font-size: 14px; line-height: 1.35; font-weight: 750;
+  word-break: keep-all;
+}
+.course-score-category {
+  margin-top: 4px;
+  color: var(--ink-3); font-size: 12px; font-weight: 600;
+  word-break: keep-all;
+}
+.course-score-metrics {
+  display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px; margin-top: 10px;
+}
+.course-score-metric {
+  min-width: 0;
+  padding: 8px 9px;
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+.course-score-metric-label {
+  color: var(--ink-3); font-size: 10.5px; font-weight: 700;
+}
+.course-score-metric-value {
+  margin-top: 4px;
+  color: var(--ink); font-size: 12.5px; font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  word-break: keep-all;
+}
+.course-score-empty {
+  margin-top: 18px;
+  padding: 16px 0;
+  border-top: 1px solid var(--rule-strong);
+  color: var(--ink-3);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+@media (max-width: 420px) {
+  .course-score-course {
+    padding: 14px;
+  }
+  .course-score-summary-meta {
+    gap: 6px;
+  }
+  .course-score-metrics {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Grade history */
 .history-overview {
   display: grid;
@@ -1622,6 +1764,7 @@ function renderData(dataType: string, data: unknown): string {
   if (!data) return "";
   const renderers: Record<string, (d: unknown) => string> = {
     timetable: renderTimetable,
+    "course-scores": renderCourseScores,
     grades: renderGrades,
     "grade-history": renderGradeHistory,
     graduation: renderGraduation,
@@ -1935,6 +2078,146 @@ function renderGrades(data: unknown): string {
   html += `</div></section>`;
 
   return html;
+}
+
+type CourseScoreValue = {
+  rawValue?: string;
+  earned?: number;
+  total?: number;
+  value?: number;
+};
+
+type CourseScoreItem = {
+  assessmentCategory?: string;
+  itemName?: string;
+  ratio?: CourseScoreValue;
+  rawScore?: CourseScoreValue;
+  averageScore?: CourseScoreValue;
+  note?: string;
+};
+
+type CourseScoreSummary = {
+  enteredItems: CourseScoreItem[];
+  courseCount: number;
+  aboveAverage: number;
+  equalAverage: number;
+  belowAverage: number;
+};
+
+type CourseScoreCourse = {
+  title?: string;
+  courseCode?: string;
+  courseTitle?: string;
+  items?: CourseScoreItem[];
+};
+
+function renderCourseScores(data: unknown): string {
+  const d = data as {
+    year?: number;
+    termLabel?: string;
+    courses?: CourseScoreCourse[];
+  };
+  const courses = (d.courses ?? []).filter((course) => course.items?.length);
+  const termText = [d.year != null ? `${d.year}학년도` : "", d.termLabel || ""].filter(Boolean).join(" · ");
+  const sectionSub = [termText, "중간·기말·퀴즈 등 학기 중 평가 항목별 점수입니다."].filter(Boolean).join(" · ");
+  if (!courses.length) {
+    return `<section class="section course-score-detail-section"><div class="section-title"><h2>과목별 상세</h2></div><div class="section-sub">${esc(sectionSub)}</div><div class="course-score-empty">조회된 수강점수 항목이 없습니다.</div></section>`;
+  }
+
+  const summary = courseScoreSummary(courses);
+
+  let html = renderCourseScoreSummary(summary);
+  html += `<section class="section course-score-detail-section"><div class="section-title"><h2>과목별 상세</h2></div><div class="section-sub">${esc(sectionSub)}</div><div class="course-score-course-list">`;
+  for (const course of courses) {
+    const courseTitle = courseScoreCourseTitle(course);
+    const courseItems = course.items ?? [];
+    html += `<section class="course-score-course"><div class="course-score-course-head"><div class="course-score-course-title">${esc(courseTitle)}</div></div>`;
+
+    for (const item of courseItems) {
+      const pending = !isCourseScoreEntered(item);
+      const statusBadge = pending ? `<span class="badge badge-gray">미공개</span>` : "";
+      html += `<article class="course-score-row"><div class="course-score-row-head"><div><div class="course-score-title">${esc(item.itemName || item.assessmentCategory || "평가 항목")}</div><div class="course-score-category">${esc(item.assessmentCategory || "")}</div></div>${statusBadge}</div>`;
+      html += `<div class="course-score-metrics">`;
+      html += renderCourseScoreMetric("반영비율", scoreValueText(item.ratio));
+      html += renderCourseScoreMetric("내 점수", pending ? "미공개" : scoreValueText(item.rawScore));
+      html += renderCourseScoreMetric("평균", scoreValueText(item.averageScore));
+      html += `</div></article>`;
+    }
+
+    html += `</section>`;
+  }
+  html += `</div></section>`;
+
+  return html;
+}
+
+function courseScoreCourseTitle(course: CourseScoreCourse): string {
+  const title = course.title?.trim();
+  if (title) return title;
+  return [course.courseCode, course.courseTitle].filter(Boolean).join(" - ") || "과목명 미정";
+}
+
+function scoreValueText(value: CourseScoreValue | undefined): string {
+  if (!value) return "-";
+  if (value.rawValue && value.rawValue.trim()) return value.rawValue.trim();
+  if (typeof value.earned === "number" && typeof value.total === "number") return `${value.earned} / ${value.total}`;
+  if (typeof value.value === "number") return String(value.value);
+  return "-";
+}
+
+function courseScoreSummary(courses: CourseScoreCourse[]): CourseScoreSummary {
+  const enteredItems = courses.flatMap((course) => course.items ?? []).filter(isCourseScoreEntered);
+  const courseCount = courses.filter((course) => (course.items ?? []).some(isCourseScoreEntered)).length;
+  let aboveAverage = 0;
+  let equalAverage = 0;
+  let belowAverage = 0;
+
+  for (const item of enteredItems) {
+    const rawScore = scoreValueNumber(item.rawScore);
+    const averageScore = scoreValueNumber(item.averageScore);
+    if (rawScore == null || averageScore == null) continue;
+    if (rawScore > averageScore) aboveAverage += 1;
+    else if (rawScore < averageScore) belowAverage += 1;
+    else equalAverage += 1;
+  }
+
+  return { enteredItems, courseCount, aboveAverage, equalAverage, belowAverage };
+}
+
+function renderCourseScoreSummary(summary: CourseScoreSummary): string {
+  if (!summary.enteredItems.length) {
+    return `<section class="course-score-summary"><div class="course-score-summary-label">공개된 수강점수</div><div class="course-score-summary-main">아직 공개된 평가 항목이 없습니다.</div></section>`;
+  }
+
+  const chips = [
+    { label: "평균보다 높음", value: summary.aboveAverage },
+    { label: "평균 동일", value: summary.equalAverage },
+    { label: "평균보다 낮음", value: summary.belowAverage },
+  ];
+  return `<section class="course-score-summary"><div class="course-score-summary-label">공개된 수강점수</div><div class="course-score-summary-main">${summary.courseCount}과목에서 ${summary.enteredItems.length}개 평가 항목이 공개됐어요.</div><div class="course-score-summary-meta">${chips.map((chip) => `<div class="course-score-summary-stat"><strong>${chip.value}</strong><span>${esc(chip.label)}</span></div>`).join("")}</div></section>`;
+}
+
+function scoreValueNumber(value: CourseScoreValue | undefined): number | undefined {
+  if (!value) return undefined;
+  if (typeof value.earned === "number") return value.earned;
+  if (typeof value.value === "number") return value.value;
+  const raw = value.rawValue?.trim();
+  if (!raw) return undefined;
+  const match = raw.match(/-?\d+(?:\.\d+)?/);
+  if (!match) return undefined;
+  return Number(match[0]);
+}
+
+function isCourseScoreEntered(item: CourseScoreItem): boolean {
+  const note = item.note?.trim().toLowerCase() || "";
+  const rawScore = scoreValueText(item.rawScore);
+  const statusText = `${note} ${rawScore}`.toLowerCase();
+  if (statusText.includes("미입력") || statusText.includes("not entered") || statusText.includes("pending")) return false;
+  return rawScore !== "-";
+}
+
+function renderCourseScoreMetric(label: string, value: string): string {
+  return `<div class="course-score-metric"><div class="course-score-metric-label">${esc(label)}</div><div class="course-score-metric-value">${esc(value)}</div></div>`;
 }
 
 function gradeTone(grade: string): "high" | "mid" | "watch" | "other" {

--- a/src/view-server.ts
+++ b/src/view-server.ts
@@ -20,6 +20,7 @@ app.use(
 
 const ALLOWED_DATA_TYPES = new Set<ViewEntry["dataType"]>([
   "timetable",
+  "course-scores",
   "grades",
   "grade-history",
   "graduation",

--- a/test/course-scores-renderer.test.cjs
+++ b/test/course-scores-renderer.test.cjs
@@ -1,0 +1,152 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { renderViewHtml } = require("../dist/view-renderer.js");
+
+function courseScoresEntry() {
+  return {
+    id: "course-scores-test-view",
+    dataType: "course-scores",
+    title: "수강점수",
+    summary: "",
+    aiResponse: "**SHOULD_NOT_RENDER_COURSE_SCORES_AI**",
+    createdAt: new Date("2026-05-03T07:00:00.000Z").getTime(),
+    expiresAt: new Date("2026-05-03T07:30:00.000Z").getTime(),
+    rawData: {
+      year: 2026,
+      termCode: "10",
+      termLabel: "1학기",
+      courses: [
+        {
+          title: "0752 - 시스템클라우드보안",
+          courseCode: "0752",
+          courseTitle: "시스템클라우드보안",
+          items: [
+            {
+              assessmentCategory: "수시시험(중간시험, QUIZ포함)",
+              itemName: "중간시험",
+              ratio: { rawValue: "40 / 40 %" },
+              rawScore: { rawValue: "0 / 100 점" },
+              averageScore: { rawValue: "0 점" },
+              note: "미입력",
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+test("course-scores renders detail section and assessment rows", () => {
+  const html = renderViewHtml(courseScoresEntry());
+  const bodyHtml = html.slice(html.indexOf("</style>"));
+
+  assert.match(html, /COURSE SCORES/);
+  assert.match(html, /수강점수/);
+  assert.match(html, /2026학년도 · 1학기/);
+  assert.match(bodyHtml, /course-score-detail-section/);
+  assert.match(bodyHtml, /과목별 상세/);
+  assert.match(bodyHtml, /class="course-score-course"/);
+  assert.match(bodyHtml, /class="course-score-course-head"/);
+  assert.match(bodyHtml, /class="course-score-course-list"/);
+  assert.doesNotMatch(bodyHtml, /grades-snapshot/);
+  assert.doesNotMatch(bodyHtml, /<span class="count">/);
+  assert.doesNotMatch(bodyHtml, /개 항목/);
+  assert.match(bodyHtml, /class="badge badge-gray">미공개<\/span>/);
+  assert.match(html, /0752 - 시스템클라우드보안/);
+  assert.match(html, /중간시험/);
+  assert.match(html, /수시시험\(중간시험, QUIZ포함\)/);
+  assert.match(html, /40 \/ 40 %/);
+  assert.match(html, /course-score-metric-label">내 점수<\/div><div class="course-score-metric-value">미공개/);
+  assert.match(html, /0 점/);
+});
+
+test("course-scores summarizes only published scores and average comparison", () => {
+  const entry = courseScoresEntry();
+  entry.rawData.courses = [
+    {
+      title: "0752 - 시스템클라우드보안",
+      items: [
+        {
+          assessmentCategory: "과제",
+          itemName: "클라우드 보안 실습 리포트",
+          ratio: { rawValue: "10 / 10 %" },
+          rawScore: { rawValue: "9 / 10 점" },
+          averageScore: { rawValue: "8.2 점" },
+          note: "입력",
+        },
+      ],
+    },
+  ];
+
+  const html = renderViewHtml(entry);
+  const bodyHtml = html.slice(html.indexOf("</style>"));
+  const summaryHtml = bodyHtml.slice(
+    bodyHtml.indexOf('class="course-score-summary"'),
+    bodyHtml.indexOf('class="section course-score-detail-section"'),
+  );
+
+  assert.match(summaryHtml, /공개된 수강점수/);
+  assert.match(summaryHtml, /1과목에서 1개 평가 항목이 공개됐어요/);
+  assert.match(summaryHtml, /<strong>1<\/strong><span>평균보다 높음<\/span>/);
+  assert.match(summaryHtml, /<strong>0<\/strong><span>평균 동일<\/span>/);
+  assert.match(summaryHtml, /<strong>0<\/strong><span>평균보다 낮음<\/span>/);
+  assert.doesNotMatch(summaryHtml, /반영비율/);
+});
+
+test("course-scores treats producer Not entered rows as pending", () => {
+  const entry = courseScoresEntry();
+  entry.rawData.courses[0].items[0].rawScore = { rawValue: "Not entered" };
+  entry.rawData.courses[0].items[0].note = "Pending";
+
+  const html = renderViewHtml(entry);
+  const bodyHtml = html.slice(html.indexOf("</style>"));
+
+  assert.match(bodyHtml, /class="badge badge-gray">미공개<\/span>/);
+  assert.match(bodyHtml, /course-score-metric-label">내 점수<\/div><div class="course-score-metric-value">미공개/);
+  assert.match(bodyHtml, /아직 공개된 평가 항목이 없습니다/);
+  assert.doesNotMatch(bodyHtml, /grades-level/);
+  assert.doesNotMatch(bodyHtml, /Pending/);
+});
+
+test("course-scores renders empty and all-entered edge states", () => {
+  const emptyEntry = courseScoresEntry();
+  emptyEntry.rawData.courses = [];
+  const emptyHtml = renderViewHtml(emptyEntry);
+  assert.match(emptyHtml, /과목별 상세/);
+  assert.match(emptyHtml, /course-score-empty/);
+  assert.match(emptyHtml, /조회된 수강점수 항목이 없습니다/);
+
+  const enteredEntry = courseScoresEntry();
+  enteredEntry.rawData.courses = [
+    {
+      courseCode: "0752",
+      courseTitle: "시스템클라우드보안",
+      items: [
+        {
+          assessmentCategory: "기말시험",
+          itemName: "기말시험",
+          ratio: { earned: 30, total: 40 },
+          rawScore: { earned: 87, total: 100 },
+          averageScore: { value: 71.5 },
+        },
+      ],
+    },
+  ];
+
+  const html = renderViewHtml(enteredEntry);
+  const bodyHtml = html.slice(html.indexOf("</style>"));
+  assert.match(html, /0752 - 시스템클라우드보안/);
+  assert.match(html, /30 \/ 40/);
+  assert.match(html, /87 \/ 100/);
+  assert.match(html, /71.5/);
+  assert.doesNotMatch(bodyHtml, /전체 입력/);
+  assert.doesNotMatch(bodyHtml, /badge-green/);
+});
+
+test("course-scores omits the AI summary even when an AI response exists", () => {
+  const html = renderViewHtml(courseScoresEntry());
+
+  assert.doesNotMatch(html, /class="briefing/);
+  assert.doesNotMatch(html, /AI 요약/);
+  assert.doesNotMatch(html, /SHOULD_NOT_RENDER_COURSE_SCORES_AI/);
+});

--- a/test/mju-wrapper-course-scores.test.cjs
+++ b/test/mju-wrapper-course-scores.test.cjs
@@ -1,0 +1,157 @@
+const assert = require("node:assert/strict");
+const { spawn } = require("node:child_process");
+const fs = require("node:fs/promises");
+const path = require("node:path");
+const test = require("node:test");
+
+function toBashPath(filePath) {
+  const normalized = path.resolve(filePath).replace(/\\/g, "/");
+  const driveMatch = normalized.match(/^([A-Za-z]):\/(.*)$/);
+  if (driveMatch) return `/mnt/${driveMatch[1].toLowerCase()}/${driveMatch[2]}`;
+  return normalized;
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function run(command, args, options) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      ...options,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => { stdout += chunk; });
+    child.stderr?.on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+async function bashCommand(command, cwd) {
+  const result = await run("bash", ["-lc", command], { cwd });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+async function createWrapperFixture(t, cliOutput) {
+  const root = path.resolve(__dirname, "..");
+  const bashNode = await bashCommand("command -v node", root);
+  const testDir = path.join(root, ".tmp", `mju-wrapper-${process.pid}-${Math.random().toString(16).slice(2)}`);
+  await fs.rm(testDir, { recursive: true, force: true });
+  await fs.mkdir(testDir, { recursive: true });
+  t.after(() => fs.rm(testDir, { recursive: true, force: true }));
+
+  const stubBin = path.join(testDir, "bin");
+  await fs.mkdir(stubBin, { recursive: true });
+  const curlCapture = path.join(testDir, "curl-body.json");
+  const curlStub = path.join(stubBin, "curl");
+  const curlCaptureForBash = toBashPath(curlCapture);
+  await fs.writeFile(curlStub, `#!/usr/bin/env bash
+set -euo pipefail
+body=""
+while (($#)); do
+  case "$1" in
+    -d)
+      shift
+      body="\${1:-}"
+      ;;
+  esac
+  shift || true
+done
+printf '%s' "$body" > "${curlCaptureForBash}"
+printf '%s\\n' '{"url":"http://view.local/course-scores-test"}'
+`, "utf8");
+  await fs.chmod(curlStub, 0o755);
+
+  const realMju = path.join(testDir, "main.js");
+  await fs.writeFile(realMju, `
+console.log(${JSON.stringify(JSON.stringify(cliOutput))});
+`, "utf8");
+
+  return { root, realMju, curlStub, bashNode, testDir, curlCapture };
+}
+
+function wrapperCommand(fixture, args) {
+  const wrapper = toBashPath(path.join(fixture.root, "bin", "mju"));
+  return [
+    `MJU_REAL_BIN=${shellQuote(toBashPath(fixture.realMju))}`,
+    `MJU_NODE_BIN=${shellQuote(fixture.bashNode)}`,
+    `MJU_CURL_BIN=${shellQuote(toBashPath(fixture.curlStub))}`,
+    `VIEW_API_URL=${shellQuote("http://127.0.0.1:1/api/view")}`,
+    shellQuote(wrapper),
+    ...args.map(shellQuote),
+  ].join(" ");
+}
+
+test("mju wrapper routes course-scores to the view API and injects viewUrl", async (t) => {
+  const fixture = await createWrapperFixture(t, {
+    year: 2026,
+    termLabel: "1학기",
+    courses: [{
+      title: "0752 - 시스템클라우드보안",
+      items: [{
+        assessmentCategory: "수시시험(중간시험, QUIZ포함)",
+        itemName: "중간시험",
+        ratio: { rawValue: "40 / 40 %" },
+        rawScore: { rawValue: "0 / 100 점" },
+        averageScore: { rawValue: "0 점" },
+        note: "미입력",
+      }],
+    }],
+  });
+
+  const result = await run("bash", ["-lc", wrapperCommand(fixture, [
+    "msi",
+    "course-scores",
+    "--app-dir",
+    toBashPath(path.join(fixture.testDir, "app")),
+    "--format",
+    "json",
+  ])], { cwd: fixture.root });
+
+  assert.equal(result.status, 0, result.stderr);
+
+  const requestBody = JSON.parse(await fs.readFile(fixture.curlCapture, "utf8"));
+  assert.equal(requestBody.dataType, "course-scores");
+  assert.equal(requestBody.title, "수강점수");
+  assert.equal(requestBody.rawData.courses[0].items[0].itemName, "중간시험");
+
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.viewUrl, "http://view.local/course-scores-test");
+  assert.equal(output.courses[0].title, "0752 - 시스템클라우드보안");
+});
+
+for (const legacyCommand of ["current-grades", "grades"]) {
+  test(`mju wrapper leaves msi ${legacyCommand} output unviewed`, async (t) => {
+    const fixture = await createWrapperFixture(t, {
+      items: [{ courseTitle: "시스템클라우드보안", grade: "A+" }],
+    });
+
+    const result = await run("bash", ["-lc", wrapperCommand(fixture, [
+      "msi",
+      legacyCommand,
+      "--app-dir",
+      toBashPath(path.join(fixture.testDir, "app")),
+      "--format",
+      "json",
+    ])], { cwd: fixture.root });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(await fileExists(fixture.curlCapture), false);
+
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.viewUrl, undefined);
+    assert.equal(output.items[0].courseTitle, "시스템클라우드보안");
+  });
+}
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/test/msi-skill-override.test.cjs
+++ b/test/msi-skill-override.test.cjs
@@ -1,0 +1,58 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const root = path.resolve(__dirname, "..");
+
+test("local mju-msi skill overrides current-term grades to course-scores", () => {
+  const skill = fs.readFileSync(path.join(root, "skills", "mju-msi", "SKILL.md"), "utf8");
+
+  assert.match(skill, /현재 학기 성적\/점수: `mju .* msi course-scores`/);
+  assert.match(skill, /"이번 학기 성적".*"현재 성적".*"수강점수"/);
+  assert.match(skill, /기존 확정등급 조회 명령은 사용하지 않습니다/);
+  assert.doesNotMatch(skill, /current-grades/);
+  assert.doesNotMatch(skill, /msi grades/);
+});
+
+test("runtime instructions avoid removed current-grade commands", () => {
+  const runtimeInstructionFiles = [
+    path.join(root, "workspace", "BOOTSTRAP.md"),
+    path.join(root, "skills", "mju-msi", "SKILL.md"),
+    path.join(root, "skills", "mju-onboarding", "SKILL.md"),
+  ];
+
+  for (const filePath of runtimeInstructionFiles) {
+    const content = fs.readFileSync(filePath, "utf8");
+    assert.doesNotMatch(content, /current-grades|msi grades/, filePath);
+  }
+
+  const bootstrap = fs.readFileSync(path.join(root, "workspace", "BOOTSTRAP.md"), "utf8");
+  assert.match(bootstrap, /이번 학기 성적.*mju msi course-scores/s);
+  assert.match(bootstrap, /현재 학기 성적 관련 의도는[\s\S]*모두 `course-scores`/);
+});
+
+test("Dockerfile copies repo-local skills after upstream mju-cli skills", () => {
+  const dockerfile = fs.readFileSync(path.join(root, "Dockerfile"), "utf8");
+  const templateUpstream = dockerfile.indexOf("COPY --chown=agent:agent mju-cli/skills/ /opt/mjuclaw-workspace-template/workspace/skills/");
+  const templateOverride = dockerfile.indexOf("COPY --chown=agent:agent skills/ /opt/mjuclaw-workspace-template/workspace/skills/");
+  const homeUpstream = dockerfile.indexOf("COPY --chown=agent:agent mju-cli/skills/ /home/agent/.openclaw/workspace/skills/");
+  const homeOverride = dockerfile.indexOf("COPY --chown=agent:agent skills/ /home/agent/.openclaw/workspace/skills/");
+
+  assert.ok(templateUpstream >= 0, "template upstream skills copy should exist");
+  assert.ok(templateOverride > templateUpstream, "repo-local template skills should override upstream skills");
+  assert.ok(homeUpstream >= 0, "home upstream skills copy should exist");
+  assert.ok(homeOverride > homeUpstream, "repo-local home skills should override upstream skills");
+});
+
+test("setup pins mju-cli to the course-scores capable branch", () => {
+  const setup = fs.readFileSync(path.join(root, "setup.sh"), "utf8");
+  const dockerfile = fs.readFileSync(path.join(root, "Dockerfile"), "utf8");
+  const readme = fs.readFileSync(path.join(root, "README.md"), "utf8");
+
+  assert.match(setup, /MJU_CLI_BRANCH="\$\{MJU_CLI_BRANCH:-msi-course-scores\}"/);
+  assert.match(setup, /git clone --branch "\$BRANCH" "\$REPO" "\$DIR"/);
+  assert.match(setup, /clone_or_pull mju-cli https:\/\/github\.com\/university-claw\/mju-cli\.git "\$MJU_CLI_BRANCH"/);
+  assert.match(dockerfile, /git clone --branch msi-course-scores https:\/\/github\.com\/university-claw\/mju-cli\.git/);
+  assert.match(readme, /git clone --branch msi-course-scores https:\/\/github\.com\/university-claw\/mju-cli\.git/);
+});

--- a/test/view-server-datatypes.test.cjs
+++ b/test/view-server-datatypes.test.cjs
@@ -88,3 +88,48 @@ test("view API accepts the grade-history data type", async (t) => {
     assert.match(body.url, new RegExp(`^http://127\\.0\\.0\\.1:${port}/view/`));
   });
 });
+
+test("view API accepts and renders the course-scores data type", async (t) => {
+  await withViewServer(t, async (port) => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/view`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        dataType: "course-scores",
+        title: "수강점수",
+        rawData: {
+          year: 2026,
+          termLabel: "1학기",
+          courses: [
+            {
+              title: "0752 - 시스템클라우드보안",
+              items: [
+                {
+                  assessmentCategory: "수시시험(중간시험, QUIZ포함)",
+                  itemName: "중간시험",
+                  ratio: { rawValue: "40 / 40 %" },
+                  rawScore: { rawValue: "0 / 100 점" },
+                  averageScore: { rawValue: "0 점" },
+                  note: "미입력",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    });
+    const body = await res.json();
+
+    assert.equal(res.status, 200);
+    assert.match(body.url, new RegExp(`^http://127\\.0\\.0\\.1:${port}/view/`));
+
+    const viewRes = await fetch(body.url);
+    const html = await viewRes.text();
+
+    assert.equal(viewRes.status, 200);
+    assert.match(html, /COURSE SCORES/);
+    assert.match(html, /0752 - 시스템클라우드보안/);
+    assert.match(html, /중간시험/);
+    assert.doesNotMatch(html, /AI 요약/);
+  });
+});

--- a/workspace/BOOTSTRAP.md
+++ b/workspace/BOOTSTRAP.md
@@ -124,11 +124,13 @@ PW_END
 
 | 유저 의도 | 사용할 명령 | dataType (자동) |
 |---|---|---|
-| "이번 학기 성적", "현재 성적" | `mju msi current-grades` | `grades` |
+| "이번 학기 성적", "현재 성적", "중간고사 점수", "기말고사 점수", "수강점수", "학기 중 점수" | `mju msi course-scores` | `course-scores` |
 | "지난 학기 성적", "전 학기 성적", "학기별 성적", "성적 이력" | `mju msi grade-history` | `grade-history` |
 | "내 졸업요건", "졸업까지" | `mju msi graduation` | `graduation` |
 
-**❌ 절대 하지 말 것**: 유저가 "지난 학기"를 물었는데 `current-grades`로 viewUrl을 만들고 AI 요약만 지난 학기 텍스트로 PATCH하는 짓. 그러면 웹뷰 본문(수강 과목 패널)은 이번 학기, AI 요약은 지난 학기로 데이터가 어긋남. 명령 자체를 의도에 맞게 골라 한 번만 실행하세요.
+현재 학기 성적 관련 의도는 최종 학점/등급이 아직 없을 수 있으므로 모두 `course-scores`로 처리하세요. 기존 확정등급 조회 명령은 사용하지 않습니다.
+
+**❌ 절대 하지 말 것**: 유저가 "지난 학기"를 물었는데 현재 학기용 명령으로 viewUrl을 만들고 AI 요약만 지난 학기 텍스트로 PATCH하는 짓. 그러면 웹뷰 본문과 AI 요약의 데이터가 어긋남. 명령 자체를 의도에 맞게 골라 한 번만 실행하세요.
 
 ### 데이터 표시 절차
 
@@ -136,7 +138,7 @@ PW_END
 
 **Step B. 필요한 경우에만 보조 AI 요약 주입**
 
-전문화된 웹뷰(`timetable`, `grades`, `grade-history`, `graduation`, `action-items`, `unsubmitted`, `unread-notices`, `attendance`, `news`, `news-detail`, `cafeteria`)는 렌더러가 화면 구조와 브리핑을 직접 만들며 `aiResponse`를 화면에 표시하지 않을 수 있습니다. 이런 웹뷰의 본문을 바꾸려고 PATCH 요약을 쓰지 마세요.
+전문화된 웹뷰(`timetable`, `course-scores`, `grades`, `grade-history`, `graduation`, `action-items`, `unsubmitted`, `unread-notices`, `attendance`, `news`, `news-detail`, `cafeteria`)는 렌더러가 화면 구조와 브리핑을 직접 만들며 `aiResponse`를 화면에 표시하지 않을 수 있습니다. 이런 웹뷰의 본문을 바꾸려고 PATCH 요약을 쓰지 마세요.
 
 범용/레거시 웹뷰에서 별도 "AI 요약" 카드가 필요한 경우에만 아래 PATCH를 사용합니다.
 


### PR DESCRIPTION
## 요약

- MSI 현재 학기 수강점수 조회 결과를 보여주는 `course-scores` 웹뷰를 추가했습니다.
- `mju msi course-scores` 실행 결과가 `bin/mju` wrapper를 통해 view-server에 저장되고, 응답 JSON에 `viewUrl`이 자동 주입되도록 했습니다.
- 수강점수 웹뷰에 공개된 평가 항목 요약 카드와 과목별 상세 섹션을 추가했습니다.
- 현재 학기 성적/점수 관련 의도는 기존 확정 성적 조회가 아니라 `mju msi course-scores`로 처리하도록 `BOOTSTRAP.md`와 MSI skill을 수정했습니다.

## 검증

- `npm test` 통과: 35/35
- `bash -n bin/mju; bash -n setup.sh; git diff --check` 통과
- 로컬 실제 데이터 통합 테스트 완료
  - 실제 `mju-cli msi course-scores` 실행
  - `mjuclaw-setup/bin/mju` wrapper 경유
  - view-server POST 성공
  - `viewUrl` 주입 확인
  - Codex 내장 브라우저에서 실제 데이터 웹뷰 렌더링 확인
