### PR TITLE
docs(readme): 다른 컴퓨터 설치 가이드 통째 rewrite (v1.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,222 +1,313 @@
 # MJUClaw Agent Setup
 
-명지대학교 학사 AI 에이전트. [OpenClaw](https://openclaw.ai)를 Docker 컨테이너에서 실행하여 Discord로 서비스합니다.
+명지대학교 학사 AI 에이전트 "묭묭이" 의 도커 기반 운영 설정. Discord DM/길드에서 학사
+서비스(LMS·MSI·UCheck·도서관·공지·학식)를 자연어로 사용한다.
 
-## 구조
+**최신 release: [v1.1.0](https://github.com/university-claw/mjuclaw-setup/releases/tag/v1.1.0)**
+— PaddleOCR 통합 + portability(다른 컴퓨터에서 한 번에 설치) 완성.
+
+---
+
+## 1. 아키텍처 한눈에
 
 ```
-Discord 유저 ↔ OpenClaw gateway (Docker) ↔ Gemini API (LLM)
-                    │
-                    ├─ mju-cli         → LMS / MSI / UCheck / 도서관
-                    ├─ mju-news        → 학교 공개 공지 스크래퍼
-                    ├─ view-server     → 학사 데이터 웹뷰 (링크 버튼)
-                    ├─ mju-news-alert  → 유저별 뉴스 정기 알림 (cron)
-                    └─ mju-attendance-alert → 수업 출석 누락 선제 알림 (cron)
+              Discord DM/Guild
+                    │ WebSocket
+        ┌───────────▼───────────┐
+        │   mjuclaw-router      │  ← Discord 봇 토큰 단독 소유
+        │   (Node 22)           │     - 온보딩 modal/login
+        │                       │     - intent classifier 게이트
+        │                       │     - cross-user session 격리
+        └───┬───────────────────┘
+            │ openclaw agent --json (gateway WS)
+            ▼
+        ┌───────────────────────┐    ┌───────────────────────┐
+        │   mjuclaw-agent       │←──▶│ mjuclaw-classifier    │
+        │   (OpenClaw + LLM)    │HTTP│ (KcELECTRA-base FastAPI│
+        │   - mju-cli wrapper   │    │  abuse 차단 + 의도 분류) │
+        │   - mju-news Reader   │    └───────────────────────┘
+        │   - view-server :3001 │
+        │   - cron alert helpers│              ▲
+        └───┬─────────┬─────────┘              │
+            │         │                         │
+       host PG       host PG                    │
+       (user_data)   (public_data)              │
+            ▲         ▲                         │
+            │         │                         │
+            │         │  ┌──────────────────────┴┐
+            │         └──│  mjuclaw-worker       │
+            │            │  (Node + PaddleOCR)   │
+            │            │  - 공지 스크래핑       │
+            │            │  - 학식 OCR (PaddleOCR)│
+            │            │  - 매 600s schedule:tick│
+            │            └───────────────────────┘
+            │
+        Discord 사용자별 vault (mju-cli SSO 크리덴셜)
 ```
 
-OpenClaw가 Discord에 직접 연결되어 에이전트로 동작합니다. 유저 메시지를 받으면 자율적으로 skill과 CLI 도구를 호출하고, LLM으로 응답을 생성합니다. 카카오 시절과 달리 **봇이 먼저 DM을 보내는 푸시 알림**도 지원합니다 (출석 누락, 새 공지 등).
+**docker-compose가 띄우는 컨테이너 (default):**
+- `mjuclaw-agent` — OpenClaw + view-server + LLM 호출 (Gemini)
+- `mjuclaw-router` — Discord WS 입구 + onboarding modal + cron alert HTTP
+- `mjuclaw-classifier` — 한국어 의도 분류 + abuse 차단 (KcELECTRA, HF Hub에서 모델 자동 download)
+- `mjuclaw-worker` — 공지/학식 정본 생성 worker (PaddleOCR)
 
-## 사전 준비
+**옵션 profile (`--profile public-data`):**
+- `mjuclaw-public-data-db` — Postgres 16-alpine (호스트 PG 없을 때 bundled DB)
+- `mjuclaw-public-data-worker` — PaddleOCR 전용 분리 worker
 
-### 1. Discord Bot
+---
 
-1. [Discord Developer Portal](https://discord.com/developers/applications) → **New Application**
-2. **Bot** → Privileged Gateway Intents 3개 켜기 (Message Content, Server Members, Presence)
-3. **Bot Token** 복사
-4. **OAuth2** → Scopes: `bot`, `applications.commands` / Permissions: View Channels, Send Messages, Read Message History, Embed Links, Attach Files, Add Reactions → 생성된 URL로 서버에 봇 초대
-5. Developer Mode 켜고 **Server ID**, **User ID** 복사
+## 2. 다른 컴퓨터에 설치 — 단계별
 
-### 2. Gemini API Key
+### 2-1. 사전 준비물 (각자 발급)
 
-[Google AI Studio](https://aistudio.google.com/apikey)에서 API 키 발급.
+| # | 항목 | 어디서 | 비고 |
+|---|---|---|---|
+| 1 | **Discord Bot Token** | [Discord Developer Portal](https://discord.com/developers/applications) | New Application → Bot → Privileged Gateway Intents 3개 ON (Message Content, Server Members, Presence) → Reset Token으로 토큰 복사 |
+| 2 | **Discord Server / User ID** | Discord 클라이언트 (Developer Mode ON) | 서버명 우클릭 → Copy ID. 본인 닉 우클릭 → Copy User ID |
+| 3 | **Bot 초대 URL** | Discord OAuth2 URL Generator | Scopes: `bot` + `applications.commands`. Permissions: Send Messages / Embed Links / Read Message History / Add Reactions / Use Slash Commands. 생성된 URL로 본인 서버에 초대 |
+| 4 | **Google Gemini API Key** | [Google AI Studio](https://aistudio.google.com/apikey) | Free tier OK |
+| 5 | **명지대 SSO 학번/비밀번호** | 본인 학교 계정 | 처음 사용자가 봇 modal에 입력 (사전 준비 X — 운영자 본인 계정도 봇에서 입력) |
+| 6 | **호스트 시스템 요구사항** | — | Docker Desktop (macOS/Windows) 또는 Docker Engine + Compose v2 (Linux). 최소 4GB RAM (PaddleOCR + Gemini 호출 동시) |
+| 7 | **(선택) ngrok account + reserved domain** | [ngrok.com](https://ngrok.com) | view-server `:3001` 외부 노출용. 학식·과제 webview 링크가 사용자 브라우저에 열리려면 공인 URL 필요. Cloudflare Tunnel 등 다른 reverse proxy도 OK |
+| 8 | **(선택) 호스트 Postgres** | brew/apt 등 직접 설치 | 옵션 A. 컨테이너 안 bundled PG 안 쓸 때 사용. **옵션 B**(bundled)도 가능 — 아래 PG 옵션 참고 |
 
-### 3. ngrok 터널 (웹뷰 공개 URL)
-
-에이전트가 학사 데이터를 조회하면 view-server가 웹뷰 URL을 생성합니다. Discord 유저가 브라우저로 열 수 있도록 ngrok 터널이 필요합니다.
+### 2-2. clone + 환경변수
 
 ```bash
-ngrok http --domain=<your-domain>.ngrok-free.dev 3001
-```
-
-## 설치 및 실행 (한 방에)
-
-```bash
-git clone https://github.com/university-claw/mjuclaw-setup.git
+# 최신 release tag로 고정 (안정)
+git clone -b v1.1.0 https://github.com/university-claw/mjuclaw-setup.git
 cd mjuclaw-setup
 
+# 또는 최신 main을 추적하려면
+git clone https://github.com/university-claw/mjuclaw-setup.git
+cd mjuclaw-setup
+```
+
+```bash
+cp .env.example .env
+# 편집 — 아래 "필수 채워야 할 변수" 참고
+${EDITOR:-vi} .env
+```
+
+#### 필수 채워야 할 변수 (`.env`)
+
+| 변수 | 채울 값 |
+|---|---|
+| `DISCORD_BOT_TOKEN` | 위 1번에서 받은 토큰 |
+| `DISCORD_SERVER_ID` | 위 2번 server ID |
+| `DISCORD_USER_ID` | 위 2번 본인 user ID (관리자 표시용) |
+| `GEMINI_API_KEY` | 위 4번 Gemini API 키 |
+| `VIEW_BASE_URL` | `https://<your-domain>.ngrok-free.dev` (위 7번) — ngrok 안 쓰면 `http://localhost:3001` (외부 사용자는 webview 링크 못 봄) |
+| `PGHOST` / `PGPORT` / `PGDATABASE` / `PGUSER` / `PGPASSWORD` / `PGSCHEMA` | 호스트 Postgres 접속 정보 (옵션 A) 또는 bundled PG의 default 값 (옵션 B). schema는 `public_data` |
+| `MJU_PGHOST` / `MJU_PGPORT` / `MJU_PGDATABASE` / `MJU_PGUSER` / `MJU_PGPASSWORD` / `MJU_PGSCHEMA` | mju-cli SSO 크리덴셜 저장용 PG (보통 위와 같은 클러스터). schema는 `user_data`. **`PGUSER`와 다른 ROLE이어야 함** (보안: public_data ROLE은 user_data 못 읽고, user_data ROLE은 public_data 못 씀) |
+| `MJU_VAULT_KEY` | `openssl rand -hex 32` 로 생성. **이 키 잃으면 SSO 비밀번호 복호화 불가** — password manager에 백업 |
+| `STORAGE_LOCAL_ROOT` | 호스트 절대경로 (예: `/Users/yourname/mjuclaw-data/assets`). worker가 공지 첨부/이미지 저장, agent는 read-only 마운트 |
+| `MJUCLAW_ROUTER_TOKEN` | `openssl rand -hex 32` (router HTTP /discord/send 인증) |
+| `OPENCLAW_GATEWAY_TOKEN` | `openssl rand -hex 32` (router → agent gateway 인증) |
+| `CLASSIFIER_AUTH_TOKEN` | `openssl rand -hex 32` (router → classifier HTTP 인증) |
+
+`.env.example`에 각 변수의 의미와 예시가 한국어 주석으로 적혀있다. 그대로 따라 채우면 됨.
+
+### 2-3. Postgres 옵션 — 두 가지 중 선택
+
+#### 옵션 A. 호스트 PG 사용 (운영 권장)
+
+호스트에 Postgres 직접 설치 + DB/스키마/ROLE 미리 생성:
+
+```bash
+# 호스트에 Postgres 설치 (예: macOS)
+brew install postgresql@17 && brew services start postgresql@17
+
+# DB + 스키마 + ROLE
+psql postgres <<'SQL'
+CREATE DATABASE mjuclaw;
+\c mjuclaw
+CREATE SCHEMA public_data;
+CREATE SCHEMA user_data;
+CREATE ROLE mjuclaw_app WITH LOGIN PASSWORD 'change-me';
+CREATE ROLE mjuclaw_user_app WITH LOGIN PASSWORD 'change-me';
+GRANT USAGE, CREATE ON SCHEMA public_data TO mjuclaw_app;
+GRANT USAGE, CREATE ON SCHEMA user_data TO mjuclaw_user_app;
+SQL
+```
+
+`.env`의 `PGHOST=host.docker.internal` (Docker Desktop 기본) 그대로 두면 컨테이너에서 호스트 PG 접근 가능.
+
+#### 옵션 B. compose 안 bundled PG 사용 (빠른 시작)
+
+`--profile public-data` 켜면 `mjuclaw-public-data-db` (Postgres 16-alpine) 컨테이너가 같이 시작된다. `.env`의 `PUBLIC_DATA_PGUSER/PASSWORD` 등을 원하는 값으로.
+
+```bash
+docker compose --profile public-data up -d --build
+```
+
+이 경우 `PGHOST=public-data-db` (compose 내부 hostname) 으로 설정.
+
+### 2-4. 실행
+
+```bash
 ./setup.sh
 ```
 
-첫 실행 시 `.env`가 자동 생성됩니다. 안내에 따라 값을 채우고 **다시 `./setup.sh`**를 실행하면 도구 레포 clone + Docker 빌드 + 기동까지 자동 완료됩니다.
+setup.sh가 자동으로:
+1. git/docker 의존성 검증
+2. 5개 sub-repo clone (`mju-cli`, `mju-news`, `mjuclaw-router`, `mju-public-data-worker`, `intent-classifier`)
+3. `.env` 필수값 검증 (누락이면 abort + 어떤 변수인지 표시)
+4. `docker compose build` (intent-classifier는 빌드 시 HF Hub에서 모델 download, worker는 PaddleOCR 설치 — 첫 빌드 5~15분)
+5. `docker compose up -d`
 
-`docker logs -f mjuclaw-agent`로 `[discord] client initialized as ... (봇이름)`이 나오면 성공.
-
-### 수동 설치 (상세 제어)
-
-```bash
-# 도구 레포 clone (gitignore 됨)
-git clone --branch msi-course-scores https://github.com/university-claw/mju-cli.git
-git clone https://github.com/university-claw/mju-news.git
-
-# 환경변수 설정
-cp .env.example .env   # 편집 필요
-
-# 빌드 & 실행
-docker compose build
-docker compose up -d
-```
-
-## 페어링 (선택 사항)
-
-기본 설정은 DM open policy라 페어링 없이 바로 대화 가능합니다. 만약 `dmPolicy`를 `pairing`으로 바꿨다면 처음 DM 시 페어링 코드를 승인해야 합니다:
+### 2-5. 정상 작동 검증
 
 ```bash
-docker exec mjuclaw-agent openclaw pairing approve discord <CODE>
+# 4개 컨테이너 모두 Up
+docker compose ps
+
+# 헬스체크
+docker exec mjuclaw-router curl -sS http://localhost:3100/healthz
+docker exec mjuclaw-agent  curl -sS http://localhost:3001/health
+docker exec mjuclaw-classifier curl -sS http://localhost:3200/healthz
+docker logs mjuclaw-worker --tail 20    # schedule:tick 로그
 ```
 
-## 환경변수
+Discord에서 본인 서버의 봇에게 DM 한 번:
+- 첫 메시지 → router가 onboarding modal 발사 (학번/비번 입력)
+- 입력 완료 → 환영 카드 + 카테고리 Poll 1건 (공지 알림 카테고리 선택)
+- 출석 알림은 시간표 기반 cron이 자동 등록됨 (수업 시작 + 5분 후 미체크 시 DM)
 
-| 변수 | 필수 | 설명 |
-|---|---|---|
-| `DISCORD_BOT_TOKEN` | O | Discord Bot Token |
-| `GEMINI_API_KEY` | O | Google Gemini API 키 |
-| `OPENCLAW_MODEL` | | LLM 모델 (기본: `gemini-2.5-flash`) |
-| `DISCORD_SERVER_ID` | | Discord 서버 ID (guild allowlist) |
-| `DISCORD_USER_ID` | | 관리자 Discord User ID |
-| `VIEW_PORT` | | view-server 포트 (기본: 3001) |
-| `VIEW_BASE_URL` | | 웹뷰 공개 URL (ngrok 도메인) |
+### 2-6. 외부 노출 (ngrok)
 
-## 영속 데이터
+view-server :3001 을 사용자가 브라우저로 열려면 외부 URL 필요. 가장 단순:
 
-Docker volume으로 컨테이너를 재생성해도 유지됩니다.
-
-| Volume | 경로 | 내용 |
-|---|---|---|
-| `agent-data` | `/home/agent/.openclaw` | 에이전트 세션, 페어링, config, cron jobs |
-| `news-data` | `/opt/mju-news/data` | 스크래핑된 공지 데이터 (공용) |
-| `user-data` | `/data/users` | 유저별 크리덴셜 vault, 구독 설정 |
-
-### 유저별 디렉토리 구조
-
-```
-/data/users/<discord_id>/
-├── vault/                          # AES-256-GCM 암호화 비밀번호
-├── state/
-│   ├── profile.json                # 학번 + authMode
-│   └── lms-session.json            # SSO 쿠키
-├── news-subscription.json          # 뉴스 정기 알림 설정
-└── attendance-alert.json           # 출석 누락 알림 설정
+```bash
+ngrok http --domain=<your-reserved-domain>.ngrok-free.dev 3001
 ```
 
-## 제공 기능
+`.env`의 `VIEW_BASE_URL=https://<your-reserved-domain>.ngrok-free.dev` 일치시킬 것. ngrok 외에 Cloudflare Tunnel/Caddy/Nginx + 도메인도 OK.
 
-### 1. 학사 데이터 조회 (온보딩 필요)
+---
 
-유저가 대화로 요청:
-- "시간표 보여줘"
-- "내 성적 어때?"
-- "남은 과제 알려줘"
-- "캡스톤디자인 출석률"
+## 3. 환경변수 reference
 
-에이전트가 `mju-cli`를 호출하고 결과를 **요약 + 웹뷰 링크 버튼**으로 전달합니다.
+전체 변수는 `.env.example`에 한국어 주석으로 설명되어 있다. 분류:
 
-### 2. 학교 공지 조회 (로그인 불필요)
-
-유저가 요청:
-- "새 공지 있어?"
-- "최근 장학금 공지"
-
-에이전트가 `mju-news`를 호출 (또는 백그라운드 cron이 이미 갱신해둔 데이터 사용).
-
-### 3. 뉴스 정기 알림 (cron 기반, 유저별)
-
-유저가 구독하면 봇이 정해진 시간에 먼저 DM:
-- "매일 아침 8시에 장학금 공지 알려줘"
-- "평일 저녁 7시에 취업 공지"
-
-`mju-news-alert` helper가 유저별 cron을 자동 생성.
-
-### 4. 출석 누락 선제 알림 (cron 기반, 유저별)
-
-유저가 구독하면 각 수업 시작 10분 후 출석 체크 여부 확인, **미체크면 자동 DM**:
-- "출석 놓치지 않게 알려줘"
-
-`mju-attendance-alert` helper가 시간표를 읽어서 수업별 cron을 자동 생성. 휴강/공휴일은 자동 건너뜀.
-
-## 온보딩 & 로그인
-
-신규 유저가 DM을 보내면 봇이 Discord 모달 폼으로 학번/비밀번호를 수집, `mju auth login`으로 검증 후 유저별 vault에 암호화 저장합니다.
-
-**온보딩 전 상태:**
-- 공개 데이터(mju-news, 뉴스 알림 구독) 사용 가능
-- 학사 데이터 조회 불가
-
-**온보딩 후:**
-- 모든 기능 사용 가능
-
-## 개인화: 유저별 격리
-
-- **대화 세션**: `session.dmScope=per-channel-peer`로 유저별 독립 (다른 유저 대화가 섞이지 않음)
-- **크리덴셜**: 유저별 디렉토리의 vault에 각자 암호화 저장
-- **cron 알림**: 유저별 cron job 이름(`news-<id>`, `attend-<id>-*`)으로 격리
-- **구독 설정**: 유저별 JSON 파일로 저장
-
-## 내장 CLI 도구
-
-컨테이너 안에 다음 도구가 설치됩니다:
-
-| 도구 | 역할 |
+| 분류 | 변수 |
 |---|---|
-| `mju` | mju-cli wrapper — 조회 결과를 view-server에 자동 저장하고 `viewUrl` 필드 주입 |
-| `mju-news` | 학교 공지 스크래핑 CLI |
-| `mju-news-alert` | 뉴스 정기 알림 subscribe/unsubscribe/status/deliver |
-| `mju-attendance-alert` | 출석 누락 알림 subscribe/unsubscribe/refresh/check |
-| `openclaw` | Gateway CLI (cron 관리, 채널 설정 등) |
+| Discord/AI | `DISCORD_BOT_TOKEN`, `GEMINI_API_KEY`, `OPENCLAW_MODEL`, `DISCORD_SERVER_ID`, `DISCORD_USER_ID`, `VIEW_PORT`, `VIEW_BASE_URL` |
+| 공개 데이터 PG | `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`, `PGSCHEMA` |
+| 사용자 데이터 PG | `MJU_PGHOST`, `MJU_PGPORT`, `MJU_PGDATABASE`, `MJU_PGUSER`, `MJU_PGPASSWORD`, `MJU_PGSCHEMA`, `MJU_STORAGE`, `MJU_VAULT_KEY` |
+| 자산 저장 | `STORAGE_LOCAL_ROOT` |
+| Router/Gateway | `MJUCLAW_ROUTER_TOKEN`, `MJUCLAW_ROUTER_URL`, `OPENCLAW_GATEWAY_URL`, `OPENCLAW_GATEWAY_TOKEN`, `ROUTER_LOG_LEVEL` |
+| Classifier | `CLASSIFIER_ENABLED`, `CLASSIFIER_URL`, `CLASSIFIER_AUTH_TOKEN`, `CLASSIFIER_TIMEOUT_MS`, `CLASSIFIER_ABUSE_THRESHOLD`, `CLASSIFIER_LOG_LEVEL` |
+| Worker | `WORKER_LOG_LEVEL`, `PUBLIC_DATA_*`, `CAFETERIA_OCR_COMMAND`, `PADDLE_OCR_REC_MODEL_NAME`, `PUBLIC_DATA_WORKER_TICK_INTERVAL_SECONDS` |
+| Sub-repo branch (release 고정용) | `MJU_CLI_BRANCH`, `MJU_NEWS_BRANCH`, `MJUCLAW_ROUTER_BRANCH`, `MJU_PUBLIC_DATA_WORKER_BRANCH`, `INTENT_CLASSIFIER_BRANCH` |
+| 외부 터널 | `NGROK_DOMAIN` |
 
-## Skill 목록
+---
 
-이미지에 16개 SKILL.md가 포함됩니다 (mju-cli의 13개 + 에이전트 전용 3개).
+## 4. 운영
 
-| Skill | 설명 |
-|---|---|
-| `mju-shared` | 공통 인증/출력 규칙 (Discord User ID 기반 app-dir) |
-| `mju-onboarding` | 로그인 흐름 |
-| `mju-lms` / `mju-lms-action-items` | LMS 강의/공지/과제 |
-| `mju-msi` | 시간표/성적/수강점수/졸업요건 |
-| `mju-ucheck` | 출석 조회 |
-| `mju-library` / `mju-library-seat-*` / `mju-library-my-*` | 도서관 |
-| `recipe-mju-*` | 복합 레시피 (일일 요약 등) |
-| `getting-mju-news` | 학교 공개 공지 |
+### 로그 확인
 
-에이전트 시스템 프롬프트는 `workspace/BOOTSTRAP.md`, `workspace/SOUL.md`, `workspace/IDENTITY.md`에 있습니다.
+```bash
+docker compose logs -f                    # 전 service
+docker logs -f mjuclaw-router             # 사용자 메시지 흐름
+docker logs -f mjuclaw-agent              # LLM + tool call
+docker logs -f mjuclaw-worker             # 공지/학식 수집
+docker logs -f mjuclaw-classifier         # abuse 분류 latency
+```
 
-## cron 작업 목록
+### cron 작업
 
 ```bash
 docker exec mjuclaw-agent openclaw cron list
 ```
 
-**시스템 cron (공용):**
-- `mju-news-scrape` — 30분마다 공지 갱신
+- `attend-<discord_id>-<gen>-<dow>-<hhmm>-<lecture>` — 사용자별 수업 시간 + 5분 후 출석 체크
+- `news-<discord_id>` — 사용자별 정기 공지 알림 (default 매일 8시)
+- `onboarding-collect-<discord_id>` — 카테고리 Poll 답변 수거 (1회성)
 
-**유저별 cron (구독 시 자동 생성):**
-- `news-<discord_id>` — 뉴스 정기 알림
-- `attend-<discord_id>-<day>-<time>-<course>` — 수업별 출석 누락 알림
+### 사용자 데이터 위치
 
-## 도구 업데이트
-
-mju-cli 또는 mju-news를 수정했으면 이미지를 다시 빌드합니다.
-
-```bash
-cd mju-cli && git pull
-cd ../mju-news && git pull
-cd ..
-docker compose build
-docker compose up -d
+```
+/data/users/<discord_id>/
+├── vault/                          # AES-256-GCM 암호화 비밀번호 (envelope encryption)
+├── state/
+│   ├── profile.json                # 학번 + authMode
+│   └── lms-session.json            # SSO 쿠키
+├── attendance-alert.json           # 출석 알림 시간표 + cron 매핑
+├── news-subscription.json          # 뉴스 알림 cron 식 + 카테고리
+└── onboarding-survey.json          # 온보딩 설문 진행 상태
 ```
 
-## 관련 레포
+> `MJU_STORAGE=postgres`이면 위 vault/profile은 Postgres `user_data` 스키마에 저장 (디렉토리는 빈 상태).
 
-- [mju-cli](https://github.com/university-claw/mju-cli) — 명지대 서비스 CLI (SSO 기반)
-- [mju-news](https://github.com/university-claw/mju-news) — 공개 공지 스크래퍼
-- [mju-server](https://github.com/university-claw/mjuclaw-server) — 카카오톡 브릿지 (deprecated)
+### Docker volume
+
+| Volume | 컨테이너 경로 | 내용 |
+|---|---|---|
+| `agent-data` | `/home/agent/.openclaw` | OpenClaw config / 세션 / cron jobs / view-store |
+| `user-data` | `/data/users` | 사용자별 vault/state (옵션 A 사용 시) |
+| `router-data` | `/home/router/.openclaw` | router의 device pairing key (재시작 시 재페어링 회피) |
+| `${STORAGE_LOCAL_ROOT}` (host mount) | `/data/assets` | worker가 저장한 공지 첨부/이미지 (agent ro 마운트) |
+| `public-data-db` | (profile 활성 시) | bundled Postgres 데이터 |
+
+### 사용자 reset
+
+특정 사용자를 처음부터 다시 onboarding하게 만들고 싶을 때:
+
+```bash
+UID=415349075274104832
+docker exec mjuclaw-agent mju-news-alert unsubscribe $UID
+docker exec mjuclaw-agent mju-attendance-alert unsubscribe $UID
+docker exec mjuclaw-agent mju-onboarding-survey reset $UID
+docker exec mjuclaw-agent mju --app-dir /data/users/$UID --format json auth forget
+docker exec mjuclaw-agent rm -rf /data/users/$UID
+docker exec mjuclaw-agent rm -f /home/agent/.openclaw/agents/main/sessions/discord-$UID.jsonl
+```
+
+---
+
+## 5. 업데이트 (이미 설치된 호스트)
+
+```bash
+cd mjuclaw-setup
+git pull
+./setup.sh           # sub-repo 자동 pull + image rebuild + restart
+```
+
+또는 release tag 변경:
+
+```bash
+git fetch --tags && git checkout v1.1.1   # 새 release 나오면
+./setup.sh
+```
+
+---
+
+## 6. 트러블슈팅
+
+| 증상 | 원인 / 조치 |
+|---|---|
+| `setup.sh: ERR: DISCORD_BOT_TOKEN must NOT be set in agent container` | docker-compose 의 agent service에 `DISCORD_BOT_TOKEN` env가 들어갔음. 보안상 router 단독 소유 정책. 해당 라인 삭제. |
+| 봇이 메시지에 응답 안 함 | router 로그에서 `Discord 클라이언트 ready` 확인. 없으면 token/intent 권한 점검. agent 로그에 LLM timeout이면 Gemini quota/연결. |
+| 학식/공지가 비어있음 | worker 로그에서 `schedule:tick` 결과 확인. PaddleOCR 첫 호출 시 모델 download(~30s) 필요. PG 연결 OK인지 `docker exec mjuclaw-worker node dist/main.js doctor`. |
+| 같은 schedule cron이 여러 개 | `mju-news-alert` / `mju-attendance-alert` 가 user-level flock + post-add dedupe로 자동 정리. 그래도 남으면 `openclaw cron remove <id>` 수동. |
+| onboarding modal 누르면 "This interaction failed" | router/agent 두 봇이 동시에 같은 토큰으로 connect 됐는지 확인. agent 컨테이너 안에 `DISCORD_BOT_TOKEN` env 없어야 함. |
+| 다른 사용자 데이터가 본인 응답에 섞임 | router의 `--session-id discord-<id>` + 메시지 prefix `[사용자ID: <id>]` 가 정상 적용됐는지 검증. agent 안 sessions 디렉토리에 사용자별 jsonl이 있어야 함. |
+
+---
+
+## 7. 관련 레포
+
+- [mju-cli](https://github.com/university-claw/mju-cli) — 명지대 서비스 CLI (LMS/MSI/UCheck/Library, SSO 기반)
+- [mju-news](https://github.com/university-claw/mju-news) — Reader CLI (worker DB → JSON)
+- [mju-public-data-worker](https://github.com/university-claw/mju-public-data-worker) — 공지/학식 정본 worker (private)
+- [mjuclaw-router](https://github.com/university-claw/mjuclaw-router) — Discord WS 입구 + 온보딩 게이트
+- [intent-classifier](https://github.com/university-claw/intent-classifier) — KcELECTRA-base 한국어 의도 분류
+
+---
+
+## 8. 라이선스 / 기여
+
+내부 프로젝트. 외부 contribution은 별도 계약 후. 보안 취약점 발견 시 GitHub Security Advisory.


### PR DESCRIPTION
v1.1.0 기준으로 README 통째 rewrite. portability 관점에서 사전 준비물(8개) + clone + .env 채우는 표 + Postgres 옵션 A/B + healthcheck 검증 + ngrok 노출 + 6가지 트러블슈팅 모두 정리. 코드 변경 없음.