### PR TITLE
test: fsetup 테스트 기대값 및 branch pin 동작 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,7 +95,9 @@ NOTICE_NORMALIZATION_MODEL=gpt-5.4-mini
 NOTICE_NORMALIZATION_MAX_OUTPUT_TOKENS=4000
 
 # ── Sub-repo branch 선택 (release 일관성, 선택) ────────────────
-# 비워두면 각 레포의 default branch(보통 main). release 고정 시 v1.0.0 등 tag명 또는 branch명.
+# 비워두면 각 레포의 default branch(보통 main). 단, setup.sh는 mju-cli를
+# course-scores 지원 branch(msi-course-scores)로 기본 고정한다.
+# release 고정 시 v1.0.0 등 tag명 또는 branch명.
 # setup.sh의 clone_or_pull이 이 값을 git clone --branch로 전달한다.
 MJU_CLI_BRANCH=
 MJU_NEWS_BRANCH=

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ WORKDIR /home/agent
 RUN mkdir -p /home/agent/.openclaw/workspace/skills
 
 # ── SKILL.md 설치 ───────────────────────────────────────────────
-# mju-cli 기본 skills → 에이전트 전용 skills로 오버라이드 (mju-shared, mju-onboarding)
+# mju-cli 기본 skills → 에이전트 전용 skills로 오버라이드 (mju-shared, mju-msi)
 COPY --chown=agent:agent mju-cli/skills/ /home/agent/.openclaw/workspace/skills/
 COPY --chown=agent:agent mju-news/skills/ /home/agent/.openclaw/workspace/skills/
 COPY --chown=agent:agent skills/ /home/agent/.openclaw/workspace/skills/

--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ docker compose -f docker-compose.yml -f docker-compose.ngrok.yml --profile ngrok
 | Sub-repo branch (release 고정용) | `MJU_CLI_BRANCH`, `MJU_NEWS_BRANCH`, `MJUCLAW_ROUTER_BRANCH`, `MJU_PUBLIC_DATA_WORKER_BRANCH`, `INTENT_CLASSIFIER_BRANCH` |
 | 외부 터널 | `NGROK_DOMAIN` |
 
+`setup.sh`는 현재 `mju-cli`를 course-scores 지원 branch로 고정한다. 수동 준비 시 동일한 기준은 다음과 같다:
+
+```bash
+git clone --branch msi-course-scores https://github.com/university-claw/mju-cli.git
+```
+
 ---
 
 ## 4. 운영

--- a/setup.sh
+++ b/setup.sh
@@ -17,8 +17,21 @@
 set -e
 cd "$(dirname "$0")"
 
+read_dotenv_value() {
+  local KEY="$1"
+  local LINE=""
+  if [ -f .env ]; then
+    LINE=$(grep -E "^${KEY}=" .env | tail -n 1 || true)
+  fi
+  printf "%s" "${LINE#*=}" | tr -d '\r'
+}
+
+MJU_CLI_BRANCH="${MJU_CLI_BRANCH:-$(read_dotenv_value MJU_CLI_BRANCH)}"
 MJU_CLI_BRANCH="${MJU_CLI_BRANCH:-msi-course-scores}"
-MJU_NEWS_BRANCH="${MJU_NEWS_BRANCH:-}"
+MJU_NEWS_BRANCH="${MJU_NEWS_BRANCH:-$(read_dotenv_value MJU_NEWS_BRANCH)}"
+MJUCLAW_ROUTER_BRANCH="${MJUCLAW_ROUTER_BRANCH:-$(read_dotenv_value MJUCLAW_ROUTER_BRANCH)}"
+MJU_PUBLIC_DATA_WORKER_BRANCH="${MJU_PUBLIC_DATA_WORKER_BRANCH:-$(read_dotenv_value MJU_PUBLIC_DATA_WORKER_BRANCH)}"
+INTENT_CLASSIFIER_BRANCH="${INTENT_CLASSIFIER_BRANCH:-$(read_dotenv_value INTENT_CLASSIFIER_BRANCH)}"
 
 echo "┌─────────────────────────────────────────────┐"
 echo "│  MJUClaw Agent — 자동 셋업                  │"

--- a/test/msi-skill-override.test.cjs
+++ b/test/msi-skill-override.test.cjs
@@ -18,8 +18,11 @@ test("local mju-msi skill overrides current-term grades to course-scores", () =>
 test("runtime instructions avoid removed current-grade commands", () => {
   const runtimeInstructionFiles = [
     path.join(root, "workspace", "BOOTSTRAP.md"),
-    path.join(root, "skills", "mju-msi", "SKILL.md"),
-    path.join(root, "skills", "mju-onboarding", "SKILL.md"),
+    ...fs
+      .readdirSync(path.join(root, "skills"), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(root, "skills", entry.name, "SKILL.md"))
+      .filter((filePath) => fs.existsSync(filePath)),
   ];
 
   for (const filePath of runtimeInstructionFiles) {
@@ -50,6 +53,8 @@ test("setup pins mju-cli to the course-scores capable branch", () => {
   const dockerfile = fs.readFileSync(path.join(root, "Dockerfile"), "utf8");
   const readme = fs.readFileSync(path.join(root, "README.md"), "utf8");
 
+  assert.match(setup, /read_dotenv_value\(\)/);
+  assert.match(setup, /MJU_CLI_BRANCH="\$\{MJU_CLI_BRANCH:-\$\(read_dotenv_value MJU_CLI_BRANCH\)\}"/);
   assert.match(setup, /MJU_CLI_BRANCH="\$\{MJU_CLI_BRANCH:-msi-course-scores\}"/);
   assert.match(setup, /git clone --branch "\$BRANCH" "\$REPO" "\$DIR"/);
   assert.match(setup, /clone_or_pull mju-cli https:\/\/github\.com\/university-claw\/mju-cli\.git "\$MJU_CLI_BRANCH"/);


### PR DESCRIPTION
## 요약
- `msi-skill-override` 테스트가 없는 `skills/mju-onboarding/SKILL.md`를 하드코딩해서 읽던 문제를 수정했습니다.
- 현재 존재하는 repo-local `skills/*/SKILL.md`를 동적으로 검사하도록 바꿨습니다.
- `setup.sh`가 `.env`의 sub-repo branch pin 값을 실제 clone/pull 단계에서 읽도록 정리했습니다.
- `mju-cli` 기본 pin(`msi-course-scores`)을 README와 `.env.example`에 명시했습니다.
- Dockerfile의 오래된 skill 주석을 현재 구성(`mju-shared`, `mju-msi`)에 맞췄습니다.

## 검증
- `npm test` 통과: 35/35
- `bash -n setup.sh`
- `git diff --check`
