### PR TITLE
ci: mjuclaw-setup agent Docker build 검증 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,34 @@ jobs:
         run: |
           mkdir -p "$STORAGE_LOCAL_ROOT"
           docker compose -f docker-compose.yml -f docker-compose.ngrok.yml config --quiet
+
+  docker-build:
+    name: Agent Docker build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Check out mju-cli build context
+        uses: actions/checkout@v4
+        with:
+          repository: university-claw/mju-cli
+          ref: main
+          path: mju-cli
+          token: ${{ secrets.CI_REPO_READ_TOKEN || github.token }}
+
+      - name: Check out mju-public-data-reader build context
+        uses: actions/checkout@v4
+        with:
+          repository: university-claw/mju-public-data-reader
+          ref: main
+          path: mju-news
+          token: ${{ secrets.CI_REPO_READ_TOKEN || github.token }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        run: docker buildx build --load -t mjuclaw-agent:test .


### PR DESCRIPTION
## 요약
- 기존 CI에 mjuclaw-agent Docker build 검증 job을 추가했습니다.
- `mju-cli`와 `mju-public-data-reader`를 CI에서 별도 checkout한 뒤, Dockerfile이 기대하는 `mju-cli/`, `mju-news/` build context로 배치합니다.
- GHCR publish는 아직 하지 않고, agent image가 GitHub Actions에서 재현 가능하게 빌드되는지만 확인합니다.

## 변경 사항
- `.github/workflows/ci.yml`
  - `docker-build` job 추가
  - `mju-cli` checkout 추가
  - `mju-public-data-reader` checkout 추가, path는 Dockerfile 호환을 위해 `mju-news`
  - `docker buildx build --load -t mjuclaw-agent:test .` 실행

## 검증
- `npm test` 통과: 35/35
- `bash -n setup.sh`
- `docker compose -f docker-compose.yml -f docker-compose.ngrok.yml config --quiet`
- `docker buildx build --load -t mjuclaw-agent:test .`
- `docker buildx build --no-cache --load -t mjuclaw-agent:test .`
- `git diff --check`

## 참고
- `mju-cli` 또는 `mju-public-data-reader` checkout 권한 문제가 생기면 repo/org secret으로 `CI_REPO_READ_TOKEN`을 추가하면 됩니다.