### PR TITLE
ci: mjuclaw-setup mjuclaw-agent GHCR 이미지 publish 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
 
 permissions:
   contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: university-claw/mjuclaw-agent
 
 jobs:
   test:
@@ -52,7 +57,7 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose.ngrok.yml config --quiet
 
   docker-build:
-    name: Agent Docker build
+    name: Agent Docker build and publish
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -79,5 +84,28 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
-        run: docker buildx build --load -t mjuclaw-agent:test .
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and optionally publish Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## 요약
- mjuclaw-setup CI에 mjuclaw-agent GHCR publish를 추가했습니다.
- PR에서는 기존처럼 agent Docker build만 검증하고, main push에서만 GHCR에 이미지를 push합니다.
- publish 태그는 `main`, `sha-<short-sha>`를 사용합니다.

## 변경 사항
- `packages: write` 권한 추가
- GHCR image 이름 설정: `ghcr.io/university-claw/mjuclaw-agent`
- `docker/login-action`, `docker/metadata-action`, `docker/build-push-action` 추가
- `mju-cli`와 `mju-public-data-reader` checkout 구조 유지
- Dockerfile 호환을 위해 `mju-public-data-reader`는 기존처럼 `mju-news` path로 checkout

## 검증
- `npm test`
- `bash -n setup.sh`
- `docker compose -f docker-compose.yml -f docker-compose.ngrok.yml config --quiet`
- `docker buildx build --load -t mjuclaw-agent:test .`
- `docker buildx build --no-cache --load -t mjuclaw-agent:test .`
- `git diff --check`
