### PR TITLE
chore: mjuclaw-setup 배포 health check와 rollback 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,18 @@ jobs:
             exit 1
           }
 
+      - name: Check deploy script argument validation
+        shell: pwsh
+        run: |
+          try {
+            ./deploy.ps1 -PullOnly -NoPull
+            throw "Expected deploy.ps1 argument validation to fail."
+          } catch {
+            if ($_.Exception.Message -notlike "*PullOnly*NoPull*") {
+              throw
+            }
+          }
+
       - name: Validate Docker Compose config
         env:
           CLASSIFIER_AUTH_TOKEN: ci-classifier-token

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env.*
 !.env.example
 release.env
+.deploy/
 .DS_Store
 node_modules/
 dist/

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -18,8 +18,8 @@
 | Production compose | 완료 | `docker-compose.prod.yml`로 GHCR image 기반 실행 |
 | Release manifest | 완료 | `release.env.example`로 image/tag 조합 고정 방식 정의 |
 | Windows deploy wrapper | 완료 | `deploy.ps1`로 pull/up 실행 |
-| Health gating | 미완료 | 수동 health check만 문서화, 자동 실패 판정은 후속 PR |
-| Rollback 자동화 | 미완료 | 이전 `release.env` 조합으로 수동 복구, 자동 rollback은 후속 PR |
+| Health gating | 완료 | `deploy.ps1`이 agent/router/classifier health endpoint를 확인하고 실패 시 non-zero exit |
+| Rollback 자동화 | 완료 | `.deploy/releases` snapshot 기반 수동 rollback과 `-RollbackOnFailure` 지원 |
 | 완전 자동 CD | 미완료 | self-hosted runner 기반 자동 배포는 아직 도입하지 않음 |
 
 ---
@@ -115,7 +115,10 @@ flowchart LR
   E --> F["docker compose config 검증"]
   F --> G["docker compose pull"]
   G --> H["docker compose up -d"]
-  H --> I["수동 health check"]
+  H --> I["자동 health check"]
+  I --> J{"health 실패?"}
+  J -- "아니오" --> K["배포 성공 기록"]
+  J -- "예 + RollbackOnFailure" --> L["이전 성공 release로 rollback"]
 ```
 
 운영 PC는 build를 수행하지 않는다. 운영 PC의 책임은 pinned image를 pull하고 compose로 띄우는 것이다.
@@ -196,7 +199,12 @@ CLASSIFIER_TAG=sha-replace-me
 .\deploy.ps1 -Ngrok
 .\deploy.ps1 -PullOnly
 .\deploy.ps1 -NoPull
+.\deploy.ps1 -SkipHealthCheck
+.\deploy.ps1 -RollbackOnFailure
+.\deploy.ps1 -RollbackLatest
+.\deploy.ps1 -Rollback .deploy\releases\20260515-123000
 .\deploy.ps1 -EnvFile .env.production -ReleaseFile release.env
+.\deploy.ps1 -HealthTimeoutSeconds 180 -HealthIntervalSeconds 10
 ```
 
 스크립트가 수행하는 일:
@@ -211,7 +219,9 @@ CLASSIFIER_TAG=sha-replace-me
 8. image pull
 9. `docker compose up -d`
 10. `docker compose ps` 출력
-11. 수동 health check 명령 출력
+11. agent/router/classifier health check
+12. worker 최근 로그 출력
+13. `.deploy/releases/<timestamp>`에 배포 기록 저장
 
 옵션별 동작:
 
@@ -220,6 +230,13 @@ CLASSIFIER_TAG=sha-replace-me
 | `-Ngrok` | `docker-compose.ngrok.yml`과 `ngrok` profile 포함 |
 | `-PullOnly` | image pull까지만 수행하고 서비스 시작 생략 |
 | `-NoPull` | 이미 pull된 image로 `up -d`만 수행 |
+| `-SkipHealthCheck` | 배포 후 자동 health check 생략 |
+| `-WaitHealthy` | health check 실행 의도를 명시적으로 드러내는 옵션. 기본값도 health check 실행 |
+| `-HealthTimeoutSeconds` | health check 전체 대기 시간. 기본 120초 |
+| `-HealthIntervalSeconds` | health 재시도 간격. 기본 5초 |
+| `-RollbackOnFailure` | health check 실패 시 직전 성공 snapshot으로 자동 rollback |
+| `-RollbackLatest` | 가장 최근 성공 snapshot으로 rollback |
+| `-Rollback <path>` | 지정한 snapshot 디렉터리 또는 `release.env` 파일로 rollback |
 | `-EnvFile` | 기본 `.env.production` 대신 지정한 env 파일 사용 |
 | `-ReleaseFile` | 기본 `release.env` 대신 지정한 release manifest 사용 |
 
@@ -277,7 +294,46 @@ docker logs mjuclaw-worker --tail 20
 - agent가 LLM/tool call 단계에서 반복 실패
 - worker가 DB 연결 또는 OCR 초기화에서 반복 실패
 
-현재 단계의 `deploy.ps1`은 자동 health gating과 rollback을 수행하지 않는다. health check 실패 시에는 이전 `release.env` tag 조합으로 되돌린 뒤 다시 실행한다.
+`deploy.ps1`은 기본적으로 배포 후 agent/router/classifier health endpoint를 확인한다. 제한 시간 안에 모든 endpoint가 성공하지 않으면 non-zero exit로 종료한다. health check를 생략해야 하는 특수 상황에서는 `-SkipHealthCheck`를 명시한다.
+
+`-RollbackOnFailure`를 함께 사용하면 health check 실패 시 직전 성공 snapshot의 `release.env`로 자동 rollback을 시도한다.
+
+---
+
+## 배포 기록과 rollback
+
+`deploy.ps1`은 실행할 때마다 `.deploy/releases/<timestamp>` 디렉터리를 만들고 현재 배포에 사용한 `release.env` snapshot과 `deploy.json` 메타데이터를 저장한다.
+
+`.deploy/`는 운영 PC의 로컬 기록이며 git에 커밋하지 않는다.
+
+`-RollbackOnFailure`와 `-RollbackLatest`는 이전에 성공으로 기록된 snapshot이 있을 때만 사용할 수 있다. 첫 배포 전에는 rollback 대상이 없으므로, 첫 성공 배포 후부터 자동 rollback이 의미를 가진다.
+
+배포 기록에는 다음 정보가 남는다.
+
+- 배포 mode: `deploy` 또는 `rollback`
+- 시작/종료 시각
+- 사용한 env 파일 경로
+- 사용한 release manifest 경로
+- snapshot된 `release.env`
+- ngrok 사용 여부
+- health check 설정
+- 배포 결과 상태
+- 실패 메시지와 rollback 대상
+
+가장 최근 성공 배포로 rollback하려면 아래 명령을 사용한다.
+
+```powershell
+.\deploy.ps1 -RollbackLatest
+```
+
+특정 snapshot으로 rollback하려면 snapshot 디렉터리 또는 snapshot 안의 `release.env`를 지정한다.
+
+```powershell
+.\deploy.ps1 -Rollback .deploy\releases\20260515-123000
+.\deploy.ps1 -Rollback .deploy\releases\20260515-123000\release.env
+```
+
+rollback도 일반 배포와 동일하게 compose config 검증, image pull, `up -d`, health check를 수행한다. pull을 생략해야 하는 경우에만 `-NoPull`을 함께 사용한다.
 
 ---
 
@@ -294,7 +350,9 @@ docker logs mjuclaw-worker --tail 20
   -> 운영 Windows PC에서 .\deploy.ps1 실행
   -> docker compose pull
   -> docker compose up -d
-  -> 수동 health check
+  -> 자동 health check
+  -> 성공/실패 배포 기록 저장
+  -> 실패 시 필요하면 이전 성공 snapshot으로 rollback
 ```
 
 이 구조의 핵심은 운영 배포 단위를 “현재 로컬 checkout 상태”가 아니라 “검증된 image tag 조합”으로 바꾸는 것이다. 따라서 운영 PC에서 어느 commit이 떠 있는지 추적할 때는 `release.env`의 `sha-*` tag 조합을 보면 된다.
@@ -305,22 +363,16 @@ docker logs mjuclaw-worker --tail 20
 
 다음 단계에서 다룰 작업은 아직 완료되지 않았다.
 
-1. `deploy.ps1` health gating 추가
-   - agent/router/classifier endpoint 자동 확인
-   - worker log sanity check
-   - 실패 시 non-zero exit
+1. 운영 PC 첫 배포 dry run
+   - `release.env`를 실제 `sha-*` tag로 채운 뒤 `.\deploy.ps1 -PullOnly` 실행
+   - GHCR 권한과 image pull 가능 여부 확인
 
-2. 배포 기록 저장
-   - 배포 시작/완료 시각
-   - 사용한 `release.env` snapshot
-   - deploy 결과
-   - health check 결과
+2. 운영 PC 실제 배포 리허설
+   - 짧은 점검 창에서 `.\deploy.ps1 -RollbackOnFailure` 실행
+   - `.deploy/releases` 기록 생성 확인
+   - health 실패 시 rollback 동작 확인
 
-3. rollback 자동화
-   - 직전 성공 release snapshot 보관
-   - 실패 시 이전 image tag 조합으로 복구
-
-4. 선택적 완전 자동 CD
+3. 선택적 완전 자동 CD
    - Windows 운영 PC에 GitHub self-hosted runner 연결
    - GitHub Environments approval/protection 적용
    - 수동 승인 후 runner가 `deploy.ps1` 실행

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -4,7 +4,14 @@ param(
   [string]$ReleaseFile = "release.env",
   [switch]$Ngrok,
   [switch]$PullOnly,
-  [switch]$NoPull
+  [switch]$NoPull,
+  [switch]$WaitHealthy,
+  [switch]$SkipHealthCheck,
+  [int]$HealthTimeoutSeconds = 120,
+  [int]$HealthIntervalSeconds = 5,
+  [switch]$RollbackOnFailure,
+  [string]$Rollback = "",
+  [switch]$RollbackLatest
 )
 
 Set-StrictMode -Version Latest
@@ -14,10 +21,41 @@ if ($PullOnly -and $NoPull) {
   throw "-PullOnly and -NoPull cannot be used together."
 }
 
+if ($WaitHealthy -and $SkipHealthCheck) {
+  throw "-WaitHealthy and -SkipHealthCheck cannot be used together."
+}
+
+if ($RollbackOnFailure -and $SkipHealthCheck) {
+  throw "-RollbackOnFailure requires health checks. Remove -SkipHealthCheck."
+}
+
+if ($PullOnly -and $RollbackOnFailure) {
+  throw "-RollbackOnFailure cannot be used with -PullOnly."
+}
+
+if ($PullOnly -and ($Rollback -or $RollbackLatest)) {
+  throw "Rollback mode cannot be used with -PullOnly."
+}
+
+if ($Rollback -and $RollbackLatest) {
+  throw "Use either -Rollback <snapshot> or -RollbackLatest, not both."
+}
+
+if ($HealthTimeoutSeconds -lt 1) {
+  throw "-HealthTimeoutSeconds must be greater than 0."
+}
+
+if ($HealthIntervalSeconds -lt 1) {
+  throw "-HealthIntervalSeconds must be greater than 0."
+}
+
 $Root = $PSScriptRoot
 if (-not $Root) {
   $Root = (Get-Location).Path
 }
+
+$DeployRoot = Join-Path $Root ".deploy"
+$ReleaseRoot = Join-Path $DeployRoot "releases"
 
 function Resolve-RepoPath {
   param(
@@ -81,6 +119,19 @@ function Invoke-Docker {
   }
 }
 
+function Invoke-DockerCapture {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Arguments
+  )
+
+  $output = & docker @Arguments 2>&1
+  return [pscustomobject]@{
+    ExitCode = $LASTEXITCODE
+    Output = ($output | Out-String).Trim()
+  }
+}
+
 function Assert-ReleaseFileIsPinned {
   param(
     [Parameter(Mandatory = $true)]
@@ -93,70 +144,396 @@ function Assert-ReleaseFileIsPinned {
   }
 }
 
-$envFilePath = Resolve-RepoPath $EnvFile
-$releaseFilePath = Resolve-RepoPath $ReleaseFile
-$prodComposePath = Resolve-RepoPath "docker-compose.prod.yml"
-$ngrokComposePath = Resolve-RepoPath "docker-compose.ngrok.yml"
+function New-ComposeArgs {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReleasePath
+  )
 
-$composeArgs = @(
-  "compose",
-  "--env-file", $envFilePath,
-  "--env-file", $releaseFilePath,
-  "-f", $prodComposePath
-)
+  $args = @(
+    "compose",
+    "--env-file", $script:EnvFilePath,
+    "--env-file", $ReleasePath,
+    "-f", $script:ProdComposePath
+  )
 
-if ($Ngrok) {
-  $composeArgs += @("-f", $ngrokComposePath, "--profile", "ngrok")
+  if ($script:NgrokEnabled) {
+    $args += @("-f", $script:NgrokComposePath, "--profile", "ngrok")
+  }
+
+  return $args
 }
 
-Push-Location $Root
-try {
-  Invoke-Step "Checking prerequisites" {
-    Assert-Command "docker"
-    Assert-File $envFilePath "env file"
-    Assert-File $releaseFilePath "release file"
-    Assert-File $prodComposePath "docker-compose.prod.yml"
-    if ($Ngrok) {
-      Assert-File $ngrokComposePath "docker-compose.ngrok.yml"
+function New-DeploymentRecord {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReleasePath,
+    [Parameter(Mandatory = $true)]
+    [string]$Mode
+  )
+
+  New-Item -ItemType Directory -Force -Path $ReleaseRoot | Out-Null
+
+  $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+  $path = Join-Path $ReleaseRoot $timestamp
+  $suffix = 1
+
+  while (Test-Path -LiteralPath $path) {
+    $path = Join-Path $ReleaseRoot "$timestamp-$suffix"
+    $suffix += 1
+  }
+
+  New-Item -ItemType Directory -Force -Path $path | Out-Null
+  Copy-Item -LiteralPath $ReleasePath -Destination (Join-Path $path "release.env") -Force
+
+  $record = [ordered]@{
+    mode = $Mode
+    status = "pending"
+    startedAt = (Get-Date).ToString("o")
+    completedAt = $null
+    envFile = $EnvFilePath
+    releaseFile = $ReleasePath
+    releaseSnapshot = (Join-Path $path "release.env")
+    ngrok = [bool]$NgrokEnabled
+    noPull = [bool]$NoPull
+    pullOnly = [bool]$PullOnly
+    healthCheck = [bool]$script:ShouldRunHealth
+    healthTimeoutSeconds = $HealthTimeoutSeconds
+    healthIntervalSeconds = $HealthIntervalSeconds
+    rollbackOnFailure = [bool]$RollbackOnFailure
+    rollbackTo = $null
+    error = $null
+  }
+
+  Write-DeploymentRecord -RecordPath $path -Record $record
+
+  return [pscustomobject]@{
+    Path = $path
+    Metadata = $record
+  }
+}
+
+function Write-DeploymentRecord {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RecordPath,
+    [Parameter(Mandatory = $true)]
+    $Record
+  )
+
+  $Record | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $RecordPath "deploy.json") -Encoding UTF8
+}
+
+function Complete-DeploymentRecord {
+  param(
+    [Parameter(Mandatory = $true)]
+    $Deployment,
+    [Parameter(Mandatory = $true)]
+    [string]$Status,
+    [string]$ErrorMessage = "",
+    [string]$RollbackTo = ""
+  )
+
+  $Deployment.Metadata.status = $Status
+  $Deployment.Metadata.completedAt = (Get-Date).ToString("o")
+  if ($ErrorMessage) {
+    $Deployment.Metadata.error = $ErrorMessage
+  }
+  if ($RollbackTo) {
+    $Deployment.Metadata.rollbackTo = $RollbackTo
+  }
+  Write-DeploymentRecord -RecordPath $Deployment.Path -Record $Deployment.Metadata
+}
+
+function Get-DeploymentRecord {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $metadataPath = Join-Path $Path "deploy.json"
+  if (-not (Test-Path -LiteralPath $metadataPath -PathType Leaf)) {
+    return $null
+  }
+
+  return Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
+}
+
+function Find-LatestSuccessfulSnapshot {
+  param(
+    [string]$ExcludePath = ""
+  )
+
+  if (-not (Test-Path -LiteralPath $ReleaseRoot -PathType Container)) {
+    return $null
+  }
+
+  $excluded = ""
+  if ($ExcludePath) {
+    $excluded = [System.IO.Path]::GetFullPath($ExcludePath)
+  }
+
+  $dirs = Get-ChildItem -LiteralPath $ReleaseRoot -Directory | Sort-Object Name -Descending
+  foreach ($dir in $dirs) {
+    $fullPath = [System.IO.Path]::GetFullPath($dir.FullName)
+    if ($excluded -and $fullPath -eq $excluded) {
+      continue
     }
 
-    Invoke-Docker -Arguments @("info", "--format", "{{.ServerVersion}}")
-    Invoke-Docker -Arguments @("compose", "version")
-    Assert-ReleaseFileIsPinned $releaseFilePath
+    $record = Get-DeploymentRecord -Path $dir.FullName
+    if (-not $record) {
+      continue
+    }
+
+    if ($record.status -notin @("succeeded", "rollback-succeeded")) {
+      continue
+    }
+
+    $releaseSnapshot = Join-Path $dir.FullName "release.env"
+    if (Test-Path -LiteralPath $releaseSnapshot -PathType Leaf) {
+      return $dir.FullName
+    }
   }
+
+  return $null
+}
+
+function Resolve-RollbackReleaseFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Snapshot
+  )
+
+  $path = Resolve-RepoPath $Snapshot
+  if (Test-Path -LiteralPath $path -PathType Leaf) {
+    return $path
+  }
+
+  if (Test-Path -LiteralPath $path -PathType Container) {
+    $releasePath = Join-Path $path "release.env"
+    Assert-File $releasePath "rollback release.env"
+    return $releasePath
+  }
+
+  throw "Rollback snapshot not found: $Snapshot"
+}
+
+function Test-HealthOnce {
+  $checks = @(
+    @{ Name = "agent"; Args = @("exec", "mjuclaw-agent", "curl", "-fsS", "--max-time", "5", "http://localhost:3001/health") },
+    @{ Name = "router"; Args = @("exec", "mjuclaw-router", "curl", "-fsS", "--max-time", "5", "http://localhost:3100/healthz") },
+    @{ Name = "classifier"; Args = @("exec", "mjuclaw-classifier", "curl", "-fsS", "--max-time", "5", "http://localhost:3200/healthz") }
+  )
+
+  $results = @()
+  foreach ($check in $checks) {
+    $result = Invoke-DockerCapture -Arguments $check.Args
+    $results += [pscustomobject]@{
+      Name = $check.Name
+      Healthy = ($result.ExitCode -eq 0)
+      Output = $result.Output
+    }
+  }
+
+  return $results
+}
+
+function Wait-Healthy {
+  $deadline = (Get-Date).AddSeconds($HealthTimeoutSeconds)
+  $lastResults = @()
+
+  do {
+    $lastResults = Test-HealthOnce
+    $failed = @($lastResults | Where-Object { -not $_.Healthy })
+
+    if ($failed.Count -eq 0) {
+      foreach ($result in $lastResults) {
+        Write-Host "  OK $($result.Name)"
+      }
+      return
+    }
+
+    $failedNames = ($failed | ForEach-Object { $_.Name }) -join ", "
+    Write-Host "  Waiting for healthy services: $failedNames"
+    Start-Sleep -Seconds $HealthIntervalSeconds
+  } while ((Get-Date) -lt $deadline)
+
+  $summary = ($lastResults | ForEach-Object {
+    $status = if ($_.Healthy) { "OK" } else { "FAIL" }
+    "$status $($_.Name): $($_.Output)"
+  }) -join "`n"
+
+  throw "Health check failed after ${HealthTimeoutSeconds}s.`n$summary"
+}
+
+function Invoke-ComposeDeployment {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReleasePath,
+    [Parameter(Mandatory = $true)]
+    [bool]$SkipPull,
+    [Parameter(Mandatory = $true)]
+    [bool]$OnlyPull,
+    [Parameter(Mandatory = $true)]
+    [bool]$RunHealth
+  )
+
+  $composeArgs = New-ComposeArgs -ReleasePath $ReleasePath
 
   Invoke-Step "Validating compose configuration" {
-    Invoke-Docker ($composeArgs + @("config", "--quiet"))
+    Invoke-Docker -Arguments ($composeArgs + @("config", "--quiet"))
   }
 
-  if (-not $NoPull) {
+  if (-not $SkipPull) {
     Invoke-Step "Pulling images" {
-      Invoke-Docker ($composeArgs + @("pull"))
+      Invoke-Docker -Arguments ($composeArgs + @("pull"))
     }
   }
 
-  if ($PullOnly) {
+  if ($OnlyPull) {
     Write-Host ""
     Write-Host "Pull complete. Skipping service start because -PullOnly was set."
     return
   }
 
   Invoke-Step "Starting services" {
-    Invoke-Docker ($composeArgs + @("up", "-d"))
+    Invoke-Docker -Arguments ($composeArgs + @("up", "-d"))
   }
 
   Invoke-Step "Current service status" {
-    Invoke-Docker ($composeArgs + @("ps"))
+    Invoke-Docker -Arguments ($composeArgs + @("ps"))
+  }
+
+  if ($RunHealth) {
+    Invoke-Step "Waiting for healthy services" {
+      Wait-Healthy
+    }
+
+    Invoke-Step "Recent worker logs" {
+      Invoke-Docker -Arguments @("logs", "mjuclaw-worker", "--tail", "20")
+    }
+  }
+  else {
+    Write-Host ""
+    Write-Host "Health checks were skipped."
+  }
+}
+
+$EnvFilePath = Resolve-RepoPath $EnvFile
+$ReleaseFilePath = Resolve-RepoPath $ReleaseFile
+$ProdComposePath = Resolve-RepoPath "docker-compose.prod.yml"
+$NgrokComposePath = Resolve-RepoPath "docker-compose.ngrok.yml"
+$NgrokEnabled = [bool]$Ngrok
+$RollbackMode = [bool]($Rollback -or $RollbackLatest)
+$ShouldRunHealth = -not [bool]$SkipHealthCheck -and -not [bool]$PullOnly
+$Deployment = $null
+$PreviousSuccessfulSnapshot = $null
+
+Push-Location $Root
+try {
+  Invoke-Step "Checking prerequisites" {
+    Assert-Command "docker"
+    Assert-File $EnvFilePath "env file"
+    Assert-File $ProdComposePath "docker-compose.prod.yml"
+    if ($NgrokEnabled) {
+      Assert-File $NgrokComposePath "docker-compose.ngrok.yml"
+    }
+
+    Invoke-Docker -Arguments @("info", "--format", "{{.ServerVersion}}")
+    Invoke-Docker -Arguments @("compose", "version")
+  }
+
+  if ($RollbackMode) {
+    if ($RollbackLatest) {
+      $snapshot = Find-LatestSuccessfulSnapshot
+      if (-not $snapshot) {
+        throw "No successful deployment snapshot found under $ReleaseRoot."
+      }
+      $ReleaseFilePath = Join-Path $snapshot "release.env"
+    }
+    else {
+      $ReleaseFilePath = Resolve-RollbackReleaseFile -Snapshot $Rollback
+    }
+
+    Assert-ReleaseFileIsPinned $ReleaseFilePath
+    $Deployment = New-DeploymentRecord -ReleasePath $ReleaseFilePath -Mode "rollback"
+    Write-Host "Rollback release file: $ReleaseFilePath"
+  }
+  else {
+    Assert-File $ReleaseFilePath "release file"
+    Assert-ReleaseFileIsPinned $ReleaseFilePath
+    $PreviousSuccessfulSnapshot = Find-LatestSuccessfulSnapshot
+    $Deployment = New-DeploymentRecord -ReleasePath $ReleaseFilePath -Mode "deploy"
+  }
+
+  Invoke-ComposeDeployment `
+    -ReleasePath $ReleaseFilePath `
+    -SkipPull ([bool]$NoPull) `
+    -OnlyPull ([bool]$PullOnly) `
+    -RunHealth $ShouldRunHealth
+
+  if ($PullOnly) {
+    Complete-DeploymentRecord -Deployment $Deployment -Status "pulled"
+  }
+  elseif ($RollbackMode) {
+    Complete-DeploymentRecord -Deployment $Deployment -Status "rollback-succeeded"
+  }
+  else {
+    Complete-DeploymentRecord -Deployment $Deployment -Status "succeeded"
   }
 
   Write-Host ""
   Write-Host "Deployment command completed."
+  Write-Host "Deployment record: $($Deployment.Path)"
+}
+catch {
+  $errorMessage = $_.Exception.Message
   Write-Host ""
-  Write-Host "Suggested health checks:"
-  Write-Host "  docker exec mjuclaw-agent curl -sS http://localhost:3001/health"
-  Write-Host "  docker exec mjuclaw-router curl -sS http://localhost:3100/healthz"
-  Write-Host "  docker exec mjuclaw-classifier curl -sS http://localhost:3200/healthz"
-  Write-Host "  docker logs mjuclaw-worker --tail 20"
+  Write-Host "Deployment failed: $errorMessage" -ForegroundColor Red
+
+  if ($Deployment) {
+    Complete-DeploymentRecord -Deployment $Deployment -Status "failed" -ErrorMessage $errorMessage
+  }
+
+  if ($RollbackOnFailure -and -not $RollbackMode) {
+    if (-not $PreviousSuccessfulSnapshot) {
+      Write-Host "No previous successful deployment snapshot is available for rollback." -ForegroundColor Yellow
+      throw
+    }
+
+    $rollbackRelease = Join-Path $PreviousSuccessfulSnapshot "release.env"
+    Write-Host ""
+    Write-Host "Rolling back to: $PreviousSuccessfulSnapshot" -ForegroundColor Yellow
+
+    try {
+      Invoke-ComposeDeployment `
+        -ReleasePath $rollbackRelease `
+        -SkipPull ([bool]$NoPull) `
+        -OnlyPull $false `
+        -RunHealth $true
+
+      Complete-DeploymentRecord `
+        -Deployment $Deployment `
+        -Status "failed-rolled-back" `
+        -ErrorMessage $errorMessage `
+        -RollbackTo $PreviousSuccessfulSnapshot
+
+      Write-Host ""
+      Write-Host "Rollback completed."
+    }
+    catch {
+      Complete-DeploymentRecord `
+        -Deployment $Deployment `
+        -Status "rollback-failed" `
+        -ErrorMessage "$errorMessage`nRollback error: $($_.Exception.Message)" `
+        -RollbackTo $PreviousSuccessfulSnapshot
+
+      Write-Host "Rollback failed: $($_.Exception.Message)" -ForegroundColor Red
+      throw
+    }
+  }
+
+  throw
 }
 finally {
   Pop-Location


### PR DESCRIPTION
## 요약
- `deploy.ps1`에 배포 후 health check를 추가했습니다.
- `.deploy/releases/<timestamp>`에 release snapshot과 배포 메타데이터를 저장합니다.
- 가장 최근 성공 snapshot 또는 지정 snapshot으로 rollback할 수 있게 했습니다.

## 변경 사항
- `deploy.ps1`
  - agent/router/classifier health endpoint 확인
  - worker 최근 로그 출력
  - `-SkipHealthCheck`, `-HealthTimeoutSeconds`, `-HealthIntervalSeconds` 추가
  - `-RollbackOnFailure`, `-RollbackLatest`, `-Rollback <path>` 추가
  - 배포 기록 `deploy.json`과 `release.env` snapshot 저장
- `.gitignore`
  - `.deploy/` 추가
- `DEPLOYMENT.md`
  - health gating, 배포 기록, rollback 절차 문서화
- CI
  - `deploy.ps1` 인자 validation 검증 추가

## 검증
- `npm test`
- `bash -n setup.sh`
- PowerShell parser로 `deploy.ps1` 검증
- `deploy.ps1 -PullOnly -NoPull` validation 검증
- local/prod/ngrok/public-data compose config 검증
- `git diff --check`

## Post-Deploy Monitoring & Validation
- 실제 운영 반영 시 `.\deploy.ps1 -RollbackOnFailure`로 실행합니다.
- 정상 신호:
  - `mjuclaw-agent`, `mjuclaw-router`, `mjuclaw-classifier`, `mjuclaw-worker`가 Up 상태
  - agent `/health`, router `/healthz`, classifier `/healthz` 통과
  - `.deploy/releases/<timestamp>/deploy.json` status가 `succeeded`
- 실패 신호:
  - health timeout
  - service Restarting/Exited
  - `deploy.json` status가 `failed`, `failed-rolled-back`, `rollback-failed`
- 실패 시 `-RollbackOnFailure`가 직전 성공 snapshot으로 rollback을 시도합니다.
