### PR TITLE
fix: deploy health check 재시도 실패 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
           if ($result.Output -notmatch "simulated stderr") {
             throw "Expected stderr to be captured, got: $($result.Output)"
           }
+          $global:LASTEXITCODE = 0
 
   docker-build:
     name: Agent Docker build and publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,61 @@ jobs:
           New-Item -ItemType Directory -Force -Path /tmp/mjuclaw-assets | Out-Null
           ./deploy.ps1 -CheckOnly -EnvFile .tmp/ci.env.production -ReleaseFile .tmp/ci.release.env
 
+  deploy-script-windows:
+    name: Deploy script Windows checks
+    runs-on: windows-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Validate Docker capture handles native stderr
+        shell: powershell
+        run: |
+          $fakeBin = Join-Path $env:RUNNER_TEMP "fake-docker"
+          New-Item -ItemType Directory -Force -Path $fakeBin | Out-Null
+          @"
+          @echo off
+          echo simulated stderr 1>&2
+          exit /b 7
+          "@ | Set-Content -Encoding ASCII -Path (Join-Path $fakeBin "docker.cmd")
+
+          $env:PATH = "$fakeBin;$env:PATH"
+
+          $tokens = $null
+          $errors = $null
+          $source = Get-Content deploy.ps1 -Raw
+          $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+            $source,
+            [ref]$tokens,
+            [ref]$errors
+          )
+          if ($errors.Count -gt 0) {
+            $errors | Format-List | Out-String | Write-Error
+            exit 1
+          }
+
+          $functionAst = $ast.Find({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+              $node.Name -eq "Invoke-DockerCapture"
+          }, $true)
+          if (-not $functionAst) {
+            throw "Invoke-DockerCapture was not found."
+          }
+
+          Invoke-Expression $functionAst.Extent.Text
+          $ErrorActionPreference = "Stop"
+          $result = Invoke-DockerCapture -Arguments @("exec", "fake", "curl")
+
+          if ($result.ExitCode -ne 7) {
+            throw "Expected exit code 7, got $($result.ExitCode)."
+          }
+          if ($result.Output -notmatch "simulated stderr") {
+            throw "Expected stderr to be captured, got: $($result.Output)"
+          }
+
   docker-build:
     name: Agent Docker build and publish
     runs-on: ubuntu-latest

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -130,10 +130,19 @@ function Invoke-DockerCapture {
     [string[]]$Arguments
   )
 
-  $output = & docker @Arguments 2>&1
+  $previousErrorActionPreference = $ErrorActionPreference
+  try {
+    $ErrorActionPreference = "Continue"
+    $output = & docker @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+  }
+  finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+  }
+
   return [pscustomobject]@{
-    ExitCode = $LASTEXITCODE
-    Output = ($output | Out-String).Trim()
+    ExitCode = $exitCode
+    Output = ($output | ForEach-Object { $_.ToString() } | Out-String).Trim()
   }
 }
 


### PR DESCRIPTION
## 요약
Windows PowerShell에서 native command stderr가 terminating error로 승격되어 `deploy.ps1` health check retry loop가 동작하지 않던 문제를 수정합니다.

## 변경 사항
- `Invoke-DockerCapture` 내부에서 native stderr를 출력 캡처 대상으로 처리
- 실패한 health check를 즉시 throw하지 않고 exit code/output으로 반환
- Windows PowerShell 기반 CI 검증 추가

## 검증
- `npm test`
- `bash -n setup.sh`
- PowerShell parser check
- deploy option validation
- Docker compose config validation
- `.\deploy.ps1 -CheckOnly`
- Windows PowerShell capture reproduction test

## Post-Deploy Monitoring & Validation
- PR merge 후 운영 PC에서 최신 `main`으로 갱신
- `.\deploy.ps1 -NoPull` 실행
- 기대 신호: health check가 agent 준비 전 실패를 만나도 재시도하며 최종 성공
- 실패 신호: `Health check failed after 120s` 또는 agent/router/classifier 중 하나가 계속 FAIL
- 성공 시 `.deploy/releases/<timestamp>`에 `status: succeeded` snapshot 생성 확인