### PR TITLE
chore: prod 배포를 단일 public-data-worker 구조로 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,8 +40,8 @@ MJU_PGSCHEMA=user_data
 # password manager / docker secret 에 반드시 백업해 둔다.
 MJU_VAULT_KEY=replace-me-with-openssl-rand-hex-32
 
-# worker가 저장한 공지 첨부/본문 이미지 원본 디렉토리 (호스트 경로).
-# 에이전트 컨테이너에 read-only로 마운트된다 (컨테이너 내부 경로: /data/assets).
+# 로컬 개발 compose에서 worker가 저장한 공지 첨부/본문 이미지 원본 디렉토리 (호스트 경로).
+# 운영 prod compose는 이 값 대신 Docker volume(public-data-assets)을 agent/worker가 공유한다.
 # 예: /Users/kbsoo/Codes/projects/mjuclaw/.data/assets
 STORAGE_LOCAL_ROOT=/absolute/path/to/mjuclaw-workspace/.data/assets
 
@@ -85,7 +85,8 @@ CLASSIFIER_ABUSE_THRESHOLD=0.25
 CLASSIFIER_LOG_LEVEL=INFO
 
 # ── Worker (mju-public-data-worker) ─────────────────────────────
-# 컨테이너 안 매 900초 schedule:tick. 호스트 launchd 의존 제거.
+# 운영 prod compose에서는 public-data profile의 mjuclaw-public-data-worker 하나만 띄운다.
+# worker와 agent는 Docker volume(public-data-assets)을 /data/assets로 공유한다.
 WORKER_LOG_LEVEL=info
 
 # Optional public notice normalization. OPENAI_API_KEY is required only when enabled.
@@ -111,11 +112,10 @@ INTENT_CLASSIFIER_BRANCH=
 NGROK_DOMAIN=
 NGROK_AUTHTOKEN=
 # ── public-data worker (PaddleOCR profile) ─────────────────────
-# 위의 worker service는 default로 시작. 별도 PaddleOCR 전용 image가 필요한
-# 케이스(EasyOCR 후보 비교, CPU 모델 비교 등)에는 PR #10의 public-data
-# profile로 분리 실행 가능:
-#   docker compose --profile public-data up -d --build
-# 또는 COMPOSE_PROFILES=public-data 환경변수.
+# 운영 prod compose에서 bundled public-data DB와 단일 public-data worker를 켜려면
+# COMPOSE_PROFILES=public-data를 설정한다.
+# 로컬 개발 compose에서도 같은 profile 이름을 사용한다.
+# COMPOSE_PROFILES=public-data
 PUBLIC_DATA_PGDATABASE=mjuclaw
 PUBLIC_DATA_PGUSER=mjuclaw_app
 PUBLIC_DATA_PGPASSWORD=change-me

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,13 @@ jobs:
           docker compose --env-file release.env.example -f docker-compose.prod.yml config --quiet
           docker compose --env-file release.env.example -f docker-compose.prod.yml --profile public-data config --quiet
           docker compose --env-file release.env.example -f docker-compose.prod.yml -f docker-compose.ngrok.yml --profile ngrok config --quiet
+          docker compose --env-file release.env.example -f docker-compose.prod.yml --profile public-data config > /tmp/prod-public-data.yml
+          if grep -q "container_name: mjuclaw-worker$" /tmp/prod-public-data.yml; then
+            echo "mjuclaw-worker must not be present in prod public-data compose config"
+            exit 1
+          fi
+          grep -q "container_name: mjuclaw-public-data-worker$" /tmp/prod-public-data.yml
+          test "$(grep -c "target: /data/assets$" /tmp/prod-public-data.yml)" -ge 2
 
       - name: Validate deploy check-only mode
         shell: pwsh
@@ -110,6 +117,7 @@ jobs:
           PGPASSWORD=ci-public-db-password
           STORAGE_LOCAL_ROOT=/tmp/mjuclaw-assets
           CLASSIFIER_AUTH_TOKEN=ci-classifier-token
+          COMPOSE_PROFILES=public-data
           "@ | Set-Content -Encoding UTF8 -Path .tmp/ci.env.production
           @"
           AGENT_IMAGE=ghcr.io/university-claw/mjuclaw-agent

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -188,12 +188,25 @@ CLASSIFIER_TAG=sha-replace-me
 - `mjuclaw-agent`
 - `mjuclaw-router`
 - `mjuclaw-classifier`
-- `mjuclaw-worker`
+- `mjuclaw-public-data-worker`
 
 옵션 profile:
 
 - `ngrok`: `docker-compose.ngrok.yml`과 함께 사용
-- `public-data`: bundled Postgres와 별도 public-data-worker profile 사용
+- `public-data`: bundled Postgres와 단일 `mjuclaw-public-data-worker` 사용
+
+운영 PC의 `.env.production`에는 `COMPOSE_PROFILES=public-data`를 설정한다. 이 profile이 꺼지면 bundled Postgres와 `mjuclaw-public-data-worker`가 실행되지 않는다.
+
+운영 compose에서는 `mjuclaw-worker`를 별도로 띄우지 않는다. public data 수집 scheduler는 `mjuclaw-public-data-worker` 하나만 실행한다.
+
+public data 원본 첨부/이미지는 Docker volume인 `public-data-assets`에 저장된다. `mjuclaw-public-data-worker`는 이 volume을 `/data/assets`에 write mount하고, `mjuclaw-agent`는 같은 volume을 `/data/assets:ro`로 read-only mount한다.
+
+기존 운영 PC에서 host bind mount `${STORAGE_LOCAL_ROOT}`를 사용해 왔다면, PR10 배포 전에 host asset을 Docker volume으로 병합한다. 이 명령은 host 파일을 삭제하지 않고, 없는 파일만 volume 쪽에 보강하는 용도다.
+
+```powershell
+$source = (Select-String -Path .env.production -Pattern '^STORAGE_LOCAL_ROOT=').Line -replace '^STORAGE_LOCAL_ROOT=', ''
+docker run --rm --mount "type=bind,source=$source,target=/from,readonly" --mount "type=volume,source=mjuclaw-setup_public-data-assets,target=/to" alpine sh -c "cd /from && cp -a . /to/"
+```
 
 ---
 
@@ -232,10 +245,11 @@ CLASSIFIER_TAG=sha-replace-me
 8. `-CheckOnly`이면 배포할 image/tag 조합 출력 후 종료
 9. image pull
 10. `docker compose up -d`
-11. `docker compose ps` 출력
-12. agent/router/classifier health check
-13. worker 최근 로그 출력
-14. `.deploy/releases/<timestamp>`에 배포 기록 저장
+11. legacy `mjuclaw-worker` orphan 컨테이너 제거
+12. `docker compose ps` 출력
+13. agent/router/classifier health check
+14. public-data worker 최근 로그 출력
+15. `.deploy/releases/<timestamp>`에 배포 기록 저장
 
 옵션별 동작:
 
@@ -290,20 +304,22 @@ docker compose --env-file .env.production --env-file release.env -f docker-compo
 docker exec mjuclaw-agent curl -sS http://localhost:3001/health
 docker exec mjuclaw-router curl -sS http://localhost:3100/healthz
 docker exec mjuclaw-classifier curl -sS http://localhost:3200/healthz
-docker logs mjuclaw-worker --tail 20
+docker logs mjuclaw-public-data-worker --tail 20
 ```
 
 정상 신호:
 
-- `mjuclaw-agent`, `mjuclaw-router`, `mjuclaw-classifier`, `mjuclaw-worker`가 Up 상태
+- `mjuclaw-agent`, `mjuclaw-router`, `mjuclaw-classifier`, `mjuclaw-public-data-worker`가 Up 상태
 - agent `/health` 응답 성공
 - router `/healthz` 응답 성공
 - classifier `/healthz` 응답 성공
 - worker 로그에서 반복적인 crash/restart가 없음
+- `mjuclaw-worker` legacy 컨테이너가 남아 있지 않음
 
 실패 신호:
 
 - compose service가 Restarting 또는 Exited 상태
+- `mjuclaw-worker`와 `mjuclaw-public-data-worker`가 동시에 실행됨
 - health endpoint가 timeout 또는 non-2xx 응답
 - router가 Discord gateway에 연결하지 못함
 - agent가 LLM/tool call 단계에서 반복 실패

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -461,6 +461,16 @@ function Wait-Healthy {
   throw "Health check failed after ${HealthTimeoutSeconds}s.`n$summary"
 }
 
+function Remove-LegacyWorkerContainer {
+  $inspect = Invoke-DockerCapture -Arguments @("inspect", "mjuclaw-worker")
+  if ($inspect.ExitCode -ne 0) {
+    Write-Host "  No legacy mjuclaw-worker container found."
+    return
+  }
+
+  Invoke-Docker -Arguments @("rm", "-f", "mjuclaw-worker")
+}
+
 function Invoke-ComposeDeployment {
   param(
     [Parameter(Mandatory = $true)]
@@ -495,6 +505,10 @@ function Invoke-ComposeDeployment {
     Invoke-Docker -Arguments ($composeArgs + @("up", "-d"))
   }
 
+  Invoke-Step "Removing legacy worker container" {
+    Remove-LegacyWorkerContainer
+  }
+
   Invoke-Step "Current service status" {
     Invoke-Docker -Arguments ($composeArgs + @("ps"))
   }
@@ -504,8 +518,8 @@ function Invoke-ComposeDeployment {
       Wait-Healthy
     }
 
-    Invoke-Step "Recent worker logs" {
-      Invoke-Docker -Arguments @("logs", "mjuclaw-worker", "--tail", "20")
+    Invoke-Step "Recent public data worker logs" {
+      Invoke-Docker -Arguments @("logs", "mjuclaw-public-data-worker", "--tail", "20")
     }
   }
   else {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -35,7 +35,7 @@ services:
     volumes:
       - agent-data:/home/agent/.openclaw
       - user-data:/data/users
-      - ${STORAGE_LOCAL_ROOT}:/data/assets:ro
+      - public-data-assets:/data/assets:ro
     depends_on:
       router:
         condition: service_started
@@ -85,24 +85,6 @@ services:
       - LOG_LEVEL=${CLASSIFIER_LOG_LEVEL:-INFO}
       - PORT=3200
 
-  worker:
-    image: ${WORKER_IMAGE:-ghcr.io/university-claw/mju-public-data-worker}:${WORKER_TAG:-main}
-    container_name: mjuclaw-worker
-    restart: unless-stopped
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    environment:
-      - PGHOST=${PGHOST:-host.docker.internal}
-      - PGPORT=${PGPORT:-5432}
-      - PGDATABASE=${PGDATABASE:-mjuclaw}
-      - PGUSER=${PGUSER:-mjuclaw_app}
-      - PGPASSWORD=${PGPASSWORD}
-      - PGSCHEMA=${PGSCHEMA:-public_data}
-      - LOG_LEVEL=${WORKER_LOG_LEVEL:-info}
-      - STORAGE_LOCAL_ROOT=/data/assets
-    volumes:
-      - ${STORAGE_LOCAL_ROOT}:/data/assets
-
   public-data-db:
     image: postgres:16-alpine
     container_name: mjuclaw-public-data-db
@@ -138,7 +120,7 @@ services:
       - PGPASSWORD=${PUBLIC_DATA_PGPASSWORD:-change-me}
       - PGSCHEMA=${PUBLIC_DATA_PGSCHEMA:-public_data}
       - STORAGE_PROVIDER=local
-      - STORAGE_LOCAL_ROOT=/data/public-assets
+      - STORAGE_LOCAL_ROOT=/data/assets
       - OCR_LANGUAGES=${PUBLIC_DATA_OCR_LANGUAGES:-kor+eng}
       - CAFETERIA_OCR_COMMAND=${CAFETERIA_OCR_COMMAND:-python scripts/cafeteria_paddleocr_candidate.py {image}}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
@@ -150,7 +132,7 @@ services:
       - PUBLIC_DATA_WORKER_TICK_INTERVAL_SECONDS=${PUBLIC_DATA_WORKER_TICK_INTERVAL_SECONDS:-600}
       - PUBLIC_DATA_WORKER_RUN_MIGRATIONS=${PUBLIC_DATA_WORKER_RUN_MIGRATIONS:-1}
     volumes:
-      - public-data-assets:/data/public-assets
+      - public-data-assets:/data/assets
       - public-data-paddle-models:/root/.paddlex
 
 volumes:


### PR DESCRIPTION
## 요약
운영 prod compose에서 `mjuclaw-worker`와 `mjuclaw-public-data-worker`가 동시에 scheduler loop를 돌 수 있던 구조를 정리합니다. 이제 prod 배포에서는 `mjuclaw-public-data-worker` 하나만 public data worker로 실행됩니다.

## 변경 사항
- `docker-compose.prod.yml`에서 legacy `worker` 서비스 제거
- `mjuclaw-public-data-worker`를 단일 scheduler worker로 유지
- `public-data-assets` Docker volume을 agent와 public-data-worker가 `/data/assets`로 공유
- `deploy.ps1`에서 legacy `mjuclaw-worker` orphan 컨테이너를 targeted cleanup
- worker 로그 확인 대상을 `mjuclaw-public-data-worker`로 변경
- CI에 prod public-data compose shape 검증 추가
- 운영 문서에 `COMPOSE_PROFILES=public-data`, asset volume 병합, health 확인 기준 반영

## 검증
- `npm test`
- `bash -n setup.sh`
- PowerShell parser check
- deploy option validation
- Docker compose config validation
- prod public-data compose shape check
- `.\deploy.ps1 -CheckOnly`
- `git diff --check`

## Post-Deploy Monitoring & Validation
- PR merge 후 운영 PC에서 host asset을 Docker volume으로 병합
- `git pull --ff-only origin main`
- `.\deploy.ps1 -CheckOnly`
- `.\deploy.ps1 -NoPull -RollbackOnFailure`
- 기대 신호:
  - `mjuclaw-public-data-worker`만 Up
  - `mjuclaw-worker`는 존재하지 않음
  - agent/router/classifier health 성공
  - public-data worker 로그에 반복 crash 없음
- 실패 신호:
  - `mjuclaw-worker`와 `mjuclaw-public-data-worker`가 동시에 실행됨
  - `mjuclaw-public-data-worker`가 Restarting/Exited
  - agent가 public data asset을 읽지 못함
- 문제 발생 시 직전 succeeded snapshot으로 rollback