### PR TITLE
ops: 운영 데이터 백업 helper script 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,21 @@ jobs:
             exit 1
           }
 
+      - name: Check backup script syntax
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $errors = $null
+          $null = [System.Management.Automation.Language.Parser]::ParseFile(
+            "backup.ps1",
+            [ref]$tokens,
+            [ref]$errors
+          )
+          if ($errors.Count -gt 0) {
+            $errors | Format-List | Out-String | Write-Error
+            exit 1
+          }
+
       - name: Check deploy script argument validation
         shell: pwsh
         run: |
@@ -73,6 +88,27 @@ jobs:
               throw
             }
           }
+
+      - name: Check backup script argument validation
+        shell: pwsh
+        run: |
+          try {
+            ./backup.ps1 -OutputRoot ""
+            throw "Expected backup.ps1 argument validation to fail."
+          } catch {
+            if ($_.Exception.Message -notlike "*OutputRoot*empty*") {
+              throw
+            }
+          }
+          try {
+            ./backup.ps1 -ComposeProjectName ""
+            throw "Expected backup.ps1 compose project validation to fail."
+          } catch {
+            if ($_.Exception.Message -notlike "*ComposeProjectName*empty*") {
+              throw
+            }
+          }
+          exit 0
 
       - name: Validate Docker Compose config
         env:
@@ -131,6 +167,27 @@ jobs:
           "@ | Set-Content -Encoding UTF8 -Path .tmp/ci.release.env
           New-Item -ItemType Directory -Force -Path /tmp/mjuclaw-assets | Out-Null
           ./deploy.ps1 -CheckOnly -EnvFile .tmp/ci.env.production -ReleaseFile .tmp/ci.release.env
+
+      - name: Validate backup check-only mode
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path .tmp | Out-Null
+          @"
+          DISCORD_BOT_TOKEN=ci-discord-token
+          GEMINI_API_KEY=ci-gemini-key
+          MJUCLAW_ROUTER_TOKEN=ci-router-token
+          MJU_PGPASSWORD=ci-user-db-password
+          MJU_VAULT_KEY=0000000000000000000000000000000000000000000000000000000000000000
+          NGROK_AUTHTOKEN=ci-ngrok-token
+          NGROK_DOMAIN=ci.example.ngrok-free.dev
+          OPENCLAW_GATEWAY_TOKEN=ci-gateway-token
+          PGPASSWORD=ci-public-db-password
+          STORAGE_LOCAL_ROOT=/tmp/mjuclaw-assets
+          CLASSIFIER_AUTH_TOKEN=ci-classifier-token
+          COMPOSE_PROFILES=public-data
+          "@ | Set-Content -Encoding UTF8 -Path .tmp/ci.env.production
+          Copy-Item release.env.example .tmp/ci.release.env
+          ./backup.ps1 -CheckOnly -EnvFile .tmp/ci.env.production -ReleaseFile .tmp/ci.release.env -OutputRoot .tmp/backups
 
   deploy-script-windows:
     name: Deploy script Windows checks

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -22,6 +22,7 @@
 | Rollback 자동화 | 완료 | `.deploy/releases` snapshot 기반 수동 rollback과 `-RollbackOnFailure` 지원 |
 | Preflight check | 완료 | `deploy.ps1 -CheckOnly`로 설정과 배포 대상 image/tag를 사전 검증 |
 | Backup/restore runbook | 완료 | 운영 PC volume과 DB 백업/복구 절차 문서화 |
+| Backup helper script | 완료 | `backup.ps1`로 운영 데이터 백업 생성 자동화 |
 | 완전 자동 CD | 미완료 | self-hosted runner 기반 자동 배포는 아직 도입하지 않음 |
 
 ---
@@ -528,7 +529,7 @@ rollback도 일반 배포와 동일하게 compose config 검증, image pull, `up
 
 ## 운영 데이터 Backup/Restore Runbook
 
-이 절차는 운영 Windows PC의 Docker Desktop 데이터 초기화, PC 교체, volume 손상 상황에서 서비스를 복구하기 위한 기준이다. 자동화 스크립트가 아니라 수동 runbook이며, restore는 운영 데이터를 덮어쓸 수 있으므로 점검 창에서만 실행한다.
+이 절차는 운영 Windows PC의 Docker Desktop 데이터 초기화, PC 교체, volume 손상 상황에서 서비스를 복구하기 위한 기준이다. 백업 생성은 `backup.ps1`로 자동화하고, restore는 운영 데이터를 덮어쓸 수 있으므로 수동 runbook으로 유지한다.
 
 ### 백업 대상
 
@@ -549,19 +550,35 @@ rollback도 일반 배포와 동일하게 compose config 검증, image pull, `up
 
 ### 백업 생성
 
-운영 PC의 `mjuclaw-setup` repo에서 실행한다.
+운영 PC의 `mjuclaw-setup` repo에서 실행한다. 기본 백업 명령은 다음과 같다.
 
 ```powershell
 cd C:\Users\yoonh\Desktop\mjuclaw-setup
-
-$backupRoot = ".deploy\backups\$(Get-Date -Format yyyyMMdd-HHmmss)"
-New-Item -ItemType Directory -Force $backupRoot | Out-Null
-
-Copy-Item .env.production (Join-Path $backupRoot ".env.production")
-Copy-Item release.env (Join-Path $backupRoot "release.env")
-Copy-Item docker-compose.prod.yml (Join-Path $backupRoot "docker-compose.prod.yml")
-Copy-Item docker-compose.ngrok.yml (Join-Path $backupRoot "docker-compose.ngrok.yml")
+.\backup.ps1
 ```
+
+자주 쓰는 옵션:
+
+```powershell
+.\backup.ps1 -CheckOnly
+.\backup.ps1 -OutputRoot .deploy\backups
+.\backup.ps1 -EnvFile .env.production -ReleaseFile release.env
+.\backup.ps1 -ComposeProjectName mjuclaw-setup
+.\backup.ps1 -SkipDbDump
+.\backup.ps1 -IncludePaddleModels
+```
+
+`backup.ps1`이 수행하는 작업:
+
+1. Docker CLI, env 파일, release 파일, compose 파일 존재 확인
+2. Docker daemon과 필수 volume 존재 확인
+3. `.deploy\backups\<timestamp>` 디렉터리 생성
+4. `.env.production`, `release.env`, compose 파일 복사
+5. `agent-data`, `router-data`, `user-data`, `public-data-assets` volume을 tar archive로 export
+6. `public-data-db`를 `pg_dump -Fc`로 dump
+7. 산출물 SHA256을 계산해 `backup.json` manifest 생성
+
+`-CheckOnly`는 입력 파일과 백업 대상 계획만 확인하고, 백업 디렉터리나 산출물을 만들지 않는다.
 
 Docker volume은 compose project 이름을 포함한 실제 volume 이름으로 백업한다. 기본 project 이름은 repo 디렉터리명 기준 `mjuclaw-setup`이다.
 
@@ -569,36 +586,14 @@ Docker volume은 compose project 이름을 포함한 실제 volume 이름으로 
 docker volume ls --format "{{.Name}}" | Select-String "mjuclaw-setup_"
 ```
 
-`COMPOSE_PROJECT_NAME`을 별도로 지정한 환경이라면 아래 명령의 `$project` 값을 실제 volume prefix에 맞춘다.
+`COMPOSE_PROJECT_NAME`을 별도로 지정한 환경이라면 `-ComposeProjectName` 값을 실제 volume prefix에 맞춘다.
 
-필수 volume을 tar로 묶는다.
-
-```powershell
-$backupPath = (Resolve-Path $backupRoot).Path
-$project = "mjuclaw-setup"
-$volumeNames = @("agent-data", "router-data", "user-data", "public-data-assets")
-
-foreach ($name in $volumeNames) {
-  $volume = "${project}_${name}"
-  docker run --rm `
-    --mount "type=volume,source=$volume,target=/data,readonly" `
-    --mount "type=bind,source=$backupPath,target=/backup" `
-    alpine sh -c "cd /data && tar czf /backup/$($name).tar.gz ."
-}
-```
-
-`public-data-db`는 컨테이너 내부에서 dump 파일을 만든 뒤 `docker cp`로 꺼낸다. PowerShell stdout redirect로 binary dump를 받으면 깨질 수 있으므로 `>` redirection은 사용하지 않는다.
+백업 결과를 확인한다. `backup.json`에는 산출물 이름, 종류, 크기, SHA256이 기록된다.
 
 ```powershell
-docker exec mjuclaw-public-data-db sh -c 'pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Fc -f /tmp/public-data-db.dump'
-docker cp "mjuclaw-public-data-db:/tmp/public-data-db.dump" (Join-Path $backupRoot "public-data-db.dump")
-docker exec mjuclaw-public-data-db rm -f /tmp/public-data-db.dump
-```
-
-백업 결과를 확인한다.
-
-```powershell
-Get-ChildItem $backupRoot
+Get-ChildItem .deploy\backups | Sort-Object Name -Descending | Select-Object -First 1
+$latest = Get-ChildItem .deploy\backups | Sort-Object Name -Descending | Select-Object -First 1
+Get-Content (Join-Path $latest.FullName "backup.json")
 ```
 
 백업 디렉터리에는 secrets가 포함된다. `.deploy/`는 gitignore 대상이지만, 운영 PC 밖으로 복사할 때도 개인 저장소나 암호화된 저장소에만 보관한다.
@@ -708,15 +703,11 @@ docker exec mjuclaw-public-data-db rm -f /tmp/public-data-db.dump
 
 다음 단계에서 다룰 작업은 아직 완료되지 않았다.
 
-1. Backup helper script
-   - 위 runbook을 바탕으로 destructive하지 않은 백업 생성만 스크립트화
-   - restore 자동화는 별도 검토 전까지 보류
-
-2. Release tag 갱신 보조 도구
+1. Release tag 갱신 보조 도구
    - 각 repo의 latest `sha-*` tag를 확인해 `release.env` 후보를 생성하는 스크립트 검토
    - 사람이 최종 승인하고 `release.env`에 반영하는 반자동 흐름 유지
 
-3. 선택적 완전 자동 CD
+2. 선택적 완전 자동 CD
    - Windows 운영 PC에 GitHub self-hosted runner 연결
    - GitHub Environments approval/protection 적용
    - 수동 승인 후 runner가 `deploy.ps1` 실행

--- a/backup.ps1
+++ b/backup.ps1
@@ -1,0 +1,326 @@
+[CmdletBinding()]
+param(
+  [string]$EnvFile = ".env.production",
+  [string]$ReleaseFile = "release.env",
+  [string]$OutputRoot = ".deploy\backups",
+  [string]$ComposeProjectName = "mjuclaw-setup",
+  [switch]$SkipDbDump,
+  [switch]$IncludePaddleModels,
+  [switch]$CheckOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not $EnvFile.Trim()) {
+  throw "-EnvFile must not be empty."
+}
+
+if (-not $ReleaseFile.Trim()) {
+  throw "-ReleaseFile must not be empty."
+}
+
+if (-not $OutputRoot.Trim()) {
+  throw "-OutputRoot must not be empty."
+}
+
+if (-not $ComposeProjectName.Trim()) {
+  throw "-ComposeProjectName must not be empty."
+}
+
+$Root = $PSScriptRoot
+if (-not $Root) {
+  $Root = (Get-Location).Path
+}
+
+function Resolve-RepoPath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $Root $Path))
+}
+
+function Assert-Command {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    throw "$Name is not installed or is not available on PATH."
+  }
+}
+
+function Assert-File {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "$Label not found: $Path"
+  }
+}
+
+function Invoke-Step {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Label,
+    [Parameter(Mandatory = $true)]
+    [scriptblock]$Action
+  )
+
+  Write-Host ""
+  Write-Host "==> $Label"
+  & $Action
+}
+
+function Invoke-Docker {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Arguments
+  )
+
+  & docker @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "docker $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+  }
+}
+
+function Invoke-DockerCapture {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Arguments
+  )
+
+  $previousErrorActionPreference = $ErrorActionPreference
+  try {
+    $ErrorActionPreference = "Continue"
+    $output = & docker @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+  }
+  finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+  }
+
+  return [pscustomobject]@{
+    ExitCode = $exitCode
+    Output = ($output | ForEach-Object { $_.ToString() } | Out-String).Trim()
+  }
+}
+
+function Assert-DockerDaemon {
+  $result = Invoke-DockerCapture -Arguments @("version", "--format", "{{.Server.Version}}")
+  if ($result.ExitCode -ne 0) {
+    throw "Docker daemon is not available. Start Docker Desktop and try again. $($result.Output)"
+  }
+}
+
+function Assert-DockerVolume {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  $result = Invoke-DockerCapture -Arguments @("volume", "inspect", $Name)
+  if ($result.ExitCode -ne 0) {
+    throw "Docker volume not found: $Name"
+  }
+}
+
+function Assert-ContainerRunning {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  $result = Invoke-DockerCapture -Arguments @("inspect", "-f", "{{.State.Running}}", $Name)
+  if ($result.ExitCode -ne 0 -or $result.Output.Trim() -ne "true") {
+    throw "Docker container is not running: $Name"
+  }
+}
+
+function Add-Artifact {
+  param(
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyCollection()]
+    [System.Collections.ArrayList]$Artifacts,
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$Kind
+  )
+
+  $item = Get-Item -LiteralPath $Path
+  $hash = Get-FileHash -LiteralPath $Path -Algorithm SHA256
+  $null = $Artifacts.Add([ordered]@{
+    name = $item.Name
+    kind = $Kind
+    bytes = $item.Length
+    sha256 = $hash.Hash.ToLowerInvariant()
+  })
+}
+
+function Copy-BackupFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Source,
+    [Parameter(Mandatory = $true)]
+    [string]$Destination,
+    [Parameter(Mandatory = $true)]
+    [string]$Kind,
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyCollection()]
+    [System.Collections.ArrayList]$Artifacts
+  )
+
+  Copy-Item -LiteralPath $Source -Destination $Destination -Force
+  Add-Artifact -Artifacts $Artifacts -Path $Destination -Kind $Kind
+}
+
+function Get-GitCommit {
+  if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    return $null
+  }
+
+  $previousErrorActionPreference = $ErrorActionPreference
+  try {
+    $ErrorActionPreference = "Continue"
+    $output = & git -C $Root rev-parse --short HEAD 2>$null
+    if ($LASTEXITCODE -eq 0) {
+      return ($output | Select-Object -First 1).ToString().Trim()
+    }
+  }
+  finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+  }
+
+  return $null
+}
+
+$EnvFilePath = Resolve-RepoPath -Path $EnvFile
+$ReleaseFilePath = Resolve-RepoPath -Path $ReleaseFile
+$OutputRootPath = Resolve-RepoPath -Path $OutputRoot
+$ProdComposePath = Join-Path $Root "docker-compose.prod.yml"
+$NgrokComposePath = Join-Path $Root "docker-compose.ngrok.yml"
+
+$volumeNames = @("agent-data", "router-data", "user-data", "public-data-assets")
+if ($IncludePaddleModels) {
+  $volumeNames += "public-data-paddle-models"
+}
+
+$fullVolumeNames = $volumeNames | ForEach-Object { "${ComposeProjectName}_$_" }
+
+Invoke-Step "Checking backup inputs" {
+  Assert-Command -Name "docker"
+  Assert-File -Path $EnvFilePath -Label "Env file"
+  Assert-File -Path $ReleaseFilePath -Label "Release file"
+  Assert-File -Path $ProdComposePath -Label "Production compose file"
+  Assert-File -Path $NgrokComposePath -Label "Ngrok compose file"
+
+  Write-Host "Env file: $EnvFilePath"
+  Write-Host "Release file: $ReleaseFilePath"
+  Write-Host "Output root: $OutputRootPath"
+  Write-Host "Compose project: $ComposeProjectName"
+  Write-Host "Volumes:"
+  foreach ($volume in $fullVolumeNames) {
+    Write-Host "  $volume"
+  }
+  if ($SkipDbDump) {
+    Write-Host "DB dump: skipped"
+  }
+  else {
+    Write-Host "DB dump: mjuclaw-public-data-db"
+  }
+}
+
+if ($CheckOnly) {
+  Write-Host ""
+  Write-Host "Check-only completed. No backup files were created."
+  exit 0
+}
+
+Invoke-Step "Checking Docker state" {
+  Assert-DockerDaemon
+  foreach ($volume in $fullVolumeNames) {
+    Assert-DockerVolume -Name $volume
+  }
+  if (-not $SkipDbDump) {
+    Assert-ContainerRunning -Name "mjuclaw-public-data-db"
+  }
+}
+
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$BackupRoot = Join-Path $OutputRootPath $timestamp
+$artifacts = [System.Collections.ArrayList]::new()
+
+Invoke-Step "Creating backup directory" {
+  New-Item -ItemType Directory -Force -Path $BackupRoot | Out-Null
+  Write-Host $BackupRoot
+}
+
+Invoke-Step "Copying configuration files" {
+  Copy-BackupFile -Source $EnvFilePath -Destination (Join-Path $BackupRoot ".env.production") -Kind "env" -Artifacts $artifacts
+  Copy-BackupFile -Source $ReleaseFilePath -Destination (Join-Path $BackupRoot "release.env") -Kind "release" -Artifacts $artifacts
+  Copy-BackupFile -Source $ProdComposePath -Destination (Join-Path $BackupRoot "docker-compose.prod.yml") -Kind "compose" -Artifacts $artifacts
+  Copy-BackupFile -Source $NgrokComposePath -Destination (Join-Path $BackupRoot "docker-compose.ngrok.yml") -Kind "compose" -Artifacts $artifacts
+}
+
+Invoke-Step "Exporting Docker volumes" {
+  foreach ($name in $volumeNames) {
+    $volume = "${ComposeProjectName}_${name}"
+    $archiveName = "$name.tar.gz"
+    Invoke-Docker -Arguments @(
+      "run", "--rm",
+      "--mount", "type=volume,source=$volume,target=/data,readonly",
+      "--mount", "type=bind,source=$BackupRoot,target=/backup",
+      "alpine", "sh", "-c", "cd /data && tar czf /backup/$archiveName ."
+    )
+    Add-Artifact -Artifacts $artifacts -Path (Join-Path $BackupRoot $archiveName) -Kind "volume"
+  }
+}
+
+if (-not $SkipDbDump) {
+  Invoke-Step "Dumping public data DB" {
+    $containerDumpPath = "/tmp/public-data-db.dump"
+    $localDumpPath = Join-Path $BackupRoot "public-data-db.dump"
+    Invoke-Docker -Arguments @(
+      "exec", "mjuclaw-public-data-db",
+      "sh", "-c", "pg_dump -U ""`$POSTGRES_USER"" -d ""`$POSTGRES_DB"" -Fc -f $containerDumpPath"
+    )
+    Invoke-Docker -Arguments @("cp", "mjuclaw-public-data-db:$containerDumpPath", $localDumpPath)
+    Invoke-Docker -Arguments @("exec", "mjuclaw-public-data-db", "rm", "-f", $containerDumpPath)
+    Add-Artifact -Artifacts $artifacts -Path $localDumpPath -Kind "database"
+  }
+}
+
+Invoke-Step "Writing backup manifest" {
+  $manifest = [ordered]@{
+    status = "succeeded"
+    createdAt = (Get-Date).ToUniversalTime().ToString("o")
+    gitCommit = Get-GitCommit
+    envFile = $EnvFile
+    releaseFile = $ReleaseFile
+    outputRoot = $OutputRoot
+    composeProjectName = $ComposeProjectName
+    skippedDbDump = [bool]$SkipDbDump
+    includedPaddleModels = [bool]$IncludePaddleModels
+    volumes = $volumeNames
+    artifacts = $artifacts
+  }
+
+  $manifestPath = Join-Path $BackupRoot "backup.json"
+  $manifest | ConvertTo-Json -Depth 6 | Set-Content -Encoding UTF8 -Path $manifestPath
+  Write-Host $manifestPath
+}
+
+Write-Host ""
+Write-Host "Backup completed: $BackupRoot"


### PR DESCRIPTION
## 요약
운영 PC에서 `.\backup.ps1` 한 번으로 배포 설정, Docker volume, public data DB 백업을 생성할 수 있도록 backup helper script를 추가했습니다.

## 변경사항
- `backup.ps1` 추가
  - `.env.production`, `release.env`, prod/ngrok compose 파일 복사
  - `agent-data`, `router-data`, `user-data`, `public-data-assets` volume tar export
  - `public-data-db` `pg_dump -Fc` dump 생성
  - 산출물 SHA256과 metadata를 `backup.json`에 기록
  - `-CheckOnly`, `-SkipDbDump`, `-IncludePaddleModels`, `-ComposeProjectName` 지원
- CI에 backup script syntax, argument validation, check-only 검증 추가
- `DEPLOYMENT.md`의 백업 절차를 `backup.ps1` 기준으로 갱신

## 검증
- PowerShell parser validation
- `backup.ps1` argument validation
- `backup.ps1 -CheckOnly`
- 임시 Docker volume 기반 `backup.ps1 -SkipDbDump`
- `npm test`
- `git diff --check`

## 배포 영향
runtime 서비스 변경은 없습니다. 운영 PC에서 백업 생성 시에만 사용하는 보조 스크립트입니다.