### PR TITLE
ops: 배포 후 smoke test helper 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,21 @@ jobs:
             exit 1
           }
 
+      - name: Check smoke test script syntax
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $errors = $null
+          $null = [System.Management.Automation.Language.Parser]::ParseFile(
+            "smoke-test.ps1",
+            [ref]$tokens,
+            [ref]$errors
+          )
+          if ($errors.Count -gt 0) {
+            $errors | Format-List | Out-String | Write-Error
+            exit 1
+          }
+
       - name: Check deploy script argument validation
         shell: pwsh
         run: |
@@ -139,6 +154,19 @@ jobs:
           try {
             ./prepare-release.ps1 -OutputRoot ""
             throw "Expected prepare-release.ps1 output root validation to fail."
+          } catch {
+            if ($_.Exception.Message -notlike "*OutputRoot*empty*") {
+              throw
+            }
+          }
+          exit 0
+
+      - name: Check smoke test script argument validation
+        shell: pwsh
+        run: |
+          try {
+            ./smoke-test.ps1 -OutputRoot ""
+            throw "Expected smoke-test.ps1 output root validation to fail."
           } catch {
             if ($_.Exception.Message -notlike "*OutputRoot*empty*") {
               throw
@@ -224,6 +252,11 @@ jobs:
           "@ | Set-Content -Encoding UTF8 -Path .tmp/ci.env.production
           Copy-Item release.env.example .tmp/ci.release.env
           ./backup.ps1 -CheckOnly -EnvFile .tmp/ci.env.production -ReleaseFile .tmp/ci.release.env -OutputRoot .tmp/backups
+
+      - name: Validate smoke test check-only mode
+        shell: pwsh
+        run: |
+          ./smoke-test.ps1 -CheckOnly -OutputRoot .tmp/smoke-tests
 
       - name: Validate prepare release check-only mode
         shell: pwsh

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -24,6 +24,7 @@
 | Backup/restore runbook | 완료 | 운영 PC volume과 DB 백업/복구 절차 문서화 |
 | Backup helper script | 완료 | `backup.ps1`로 운영 데이터 백업 생성 자동화 |
 | Release candidate helper | 완료 | `prepare-release.ps1`로 `release.env` 후보 생성 |
+| Smoke test helper | 완료 | `smoke-test.ps1`로 배포 후 service/worker smoke test와 기록 생성 |
 | 운영 PC 반자동 리허설 | 완료 | release 후보 생성, 백업, 배포, smoke test 전체 흐름 검증 |
 | Self-hosted runner 운영 기준 | 완료 | 운영 PC runner 보안/실행 경계와 실제 실행 기준 문서화 |
 | Production dry-run workflow | 완료 | `workflow_dispatch` 기반 check-only workflow 추가 및 운영 PC dry-run 성공 확인 |
@@ -540,29 +541,40 @@ docker logs mjuclaw-public-data-worker --tail 20
 
 배포 후에는 health check만 보지 말고 실제 사용자 흐름을 한 번 확인한다.
 
-기본 service health:
+기본 smoke test helper:
 
 ```powershell
-docker exec mjuclaw-agent curl -sS http://localhost:3001/health
-docker exec mjuclaw-router curl -sS http://localhost:3100/healthz
-docker exec mjuclaw-classifier curl -sS http://localhost:3200/healthz
+.\smoke-test.ps1 -CheckOnly
+.\smoke-test.ps1
 ```
 
-Discord/LLM smoke:
+`smoke-test.ps1`는 다음 항목을 검증한다.
+
+- Docker daemon 접근 가능 여부
+- agent `/health`
+- router `/healthz`
+- classifier `/healthz`
+- legacy `mjuclaw-worker` container 부재
+- public data worker container 실행 상태
+- public data worker `doctor`
+- public data worker `schedule tick --dry-run`
+
+결과는 `.deploy\smoke-tests\<timestamp>\smoke-test.json`에 저장된다. 실패하면 non-zero exit로 종료하므로 운영자가 실패 원인을 확인한 뒤 rollback 또는 재배포를 결정한다.
+
+public data worker 검증을 잠시 제외해야 하는 경우에만 아래 옵션을 사용한다.
+
+```powershell
+.\smoke-test.ps1 -SkipPublicDataWorker
+```
+
+Discord/LLM smoke는 아직 자동화하지 않는다. 배포 후 운영자가 아래 흐름을 수동으로 확인한다.
 
 - Discord에서 실제 대화 1회 전송
 - router 로그에서 Discord client ready와 메시지 처리 확인
 - agent가 LLM 응답을 반환하는지 확인
 - 사용자 session이 `discord-<user-id>` 기준으로 분리되는지 확인
 
-public data worker smoke:
-
-```powershell
-docker exec mjuclaw-public-data-worker node dist/main.js doctor
-docker exec mjuclaw-public-data-worker node dist/main.js schedule tick --dry-run
-```
-
-필요할 때만 실제 수집을 1건 실행한다.
+필요할 때만 public data 실제 수집을 1건 실행한다.
 
 ```powershell
 docker exec mjuclaw-public-data-worker node dist/main.js collect notices --limit 1
@@ -964,9 +976,9 @@ runner 도입 후 문제가 생기면 아래 순서로 반자동 운영으로 �
    - 현재 `run.cmd`로 임시 실행 중이면 Windows Service 등록을 검토한다.
    - 서비스화할 경우 재부팅 후 runner 자동 시작과 Docker Desktop 접근 권한을 확인한다.
 
-2. 배포 후 smoke test 자동화 검토
-   - router/agent health 외에 Discord 대화, LLM 응답, public data worker dry-run 검증을 workflow 또는 별도 runbook으로 묶을지 결정한다.
-   - 자동화 전까지는 배포 후 운영자가 기존 smoke test를 수동 확인한다.
+2. Production Deploy workflow에 smoke test 연결 검토
+   - `deploy.ps1 -RollbackOnFailure` 성공 후 `smoke-test.ps1`를 실행할지 결정한다.
+   - Discord/LLM 실제 대화 검증은 side effect가 있으므로 계속 수동 smoke로 유지한다.
 
 3. main push 즉시 자동 배포는 계속 보류
    - 승인 기반 `workflow_dispatch` 운영을 기본으로 유지한다.

--- a/smoke-test.ps1
+++ b/smoke-test.ps1
@@ -1,0 +1,283 @@
+[CmdletBinding()]
+param(
+  [string]$OutputRoot = ".deploy\smoke-tests",
+  [switch]$SkipPublicDataWorker,
+  [switch]$CheckOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not $OutputRoot.Trim()) {
+  throw "-OutputRoot must not be empty."
+}
+
+$Root = $PSScriptRoot
+if (-not $Root) {
+  $Root = (Get-Location).Path
+}
+
+function Resolve-RepoPath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $Root $Path))
+}
+
+function Assert-Command {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    throw "$Name is not installed or is not available on PATH."
+  }
+}
+
+function Invoke-Step {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Label,
+    [Parameter(Mandatory = $true)]
+    [scriptblock]$Action
+  )
+
+  Write-Host ""
+  Write-Host "==> $Label"
+  & $Action
+}
+
+function Invoke-DockerCapture {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Arguments
+  )
+
+  $previousErrorActionPreference = $ErrorActionPreference
+  try {
+    $ErrorActionPreference = "Continue"
+    $output = & docker @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+  }
+  finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+  }
+
+  return [pscustomobject]@{
+    ExitCode = $exitCode
+    Output = ($output | ForEach-Object { $_.ToString() } | Out-String).Trim()
+  }
+}
+
+function Assert-DockerDaemon {
+  $result = Invoke-DockerCapture -Arguments @("version", "--format", "{{.Server.Version}}")
+  if ($result.ExitCode -ne 0) {
+    throw "Docker daemon is not available. Start Docker Desktop and try again. $($result.Output)"
+  }
+}
+
+function Get-GitCommit {
+  if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    return $null
+  }
+
+  $previousErrorActionPreference = $ErrorActionPreference
+  try {
+    $ErrorActionPreference = "Continue"
+    $output = & git -C $Root rev-parse --short HEAD 2>$null
+    if ($LASTEXITCODE -eq 0) {
+      return ($output | Select-Object -First 1).ToString().Trim()
+    }
+  }
+  finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+  }
+
+  return $null
+}
+
+function Invoke-SmokeCheck {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+    [Parameter(Mandatory = $true)]
+    [string[]]$Arguments
+  )
+
+  $startedAt = (Get-Date).ToUniversalTime()
+  Write-Host "  $Name"
+
+  $result = Invoke-DockerCapture -Arguments $Arguments
+  $completedAt = (Get-Date).ToUniversalTime()
+  $durationMs = [int][Math]::Round(($completedAt - $startedAt).TotalMilliseconds)
+
+  $status = if ($result.ExitCode -eq 0) { "succeeded" } else { "failed" }
+  $check = [ordered]@{
+    name = $Name
+    status = $status
+    exitCode = $result.ExitCode
+    output = $result.Output
+    startedAt = $startedAt.ToString("o")
+    completedAt = $completedAt.ToString("o")
+    durationMs = $durationMs
+  }
+  $null = $script:Checks.Add($check)
+
+  if ($result.ExitCode -ne 0) {
+    throw "$Name failed. $($result.Output)"
+  }
+}
+
+function Invoke-ContainerRunningCheck {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+    [Parameter(Mandatory = $true)]
+    [string]$Container
+  )
+
+  Invoke-SmokeCheck -Name $Name -Arguments @("inspect", "-f", "{{.State.Running}}", $Container)
+  $lastCheck = $script:Checks[$script:Checks.Count - 1]
+  if ($lastCheck["output"].Trim() -ne "true") {
+    $lastCheck["status"] = "failed"
+    throw "$Container is not running."
+  }
+}
+
+function Invoke-LegacyWorkerAbsentCheck {
+  $name = "legacy-worker-absent"
+  $startedAt = (Get-Date).ToUniversalTime()
+  Write-Host "  $name"
+
+  $result = Invoke-DockerCapture -Arguments @("inspect", "mjuclaw-worker")
+  $completedAt = (Get-Date).ToUniversalTime()
+  $durationMs = [int][Math]::Round(($completedAt - $startedAt).TotalMilliseconds)
+  $legacyPresent = ($result.ExitCode -eq 0)
+  $status = if ($legacyPresent) { "failed" } else { "succeeded" }
+
+  $check = [ordered]@{
+    name = $name
+    status = $status
+    exitCode = $result.ExitCode
+    output = $result.Output
+    startedAt = $startedAt.ToString("o")
+    completedAt = $completedAt.ToString("o")
+    durationMs = $durationMs
+  }
+  $null = $script:Checks.Add($check)
+
+  if ($legacyPresent) {
+    throw "Legacy mjuclaw-worker container is present. Remove it before treating this deployment as healthy."
+  }
+}
+
+function Write-SmokeRecord {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Status,
+    [AllowNull()]
+    [string]$ErrorMessage
+  )
+
+  $completedAt = (Get-Date).ToUniversalTime()
+  $durationMs = [int][Math]::Round(($completedAt - $script:StartedAt).TotalMilliseconds)
+  $record = [ordered]@{
+    schemaVersion = 1
+    status = $Status
+    startedAt = $script:StartedAt.ToString("o")
+    completedAt = $completedAt.ToString("o")
+    durationMs = $durationMs
+    gitCommit = Get-GitCommit
+    skipPublicDataWorker = [bool]$SkipPublicDataWorker
+    checks = @($script:Checks)
+  }
+
+  if ($ErrorMessage) {
+    $record["error"] = $ErrorMessage
+  }
+
+  $recordPath = Join-Path $script:RunRoot "smoke-test.json"
+  $record | ConvertTo-Json -Depth 8 | Set-Content -Encoding UTF8 -Path $recordPath
+  Write-Host ""
+  Write-Host "Smoke test record: $recordPath"
+}
+
+$OutputRootPath = Resolve-RepoPath -Path $OutputRoot
+
+Invoke-Step "Checking smoke test inputs" {
+  Write-Host "Output root: $OutputRootPath"
+  Write-Host "Public data worker checks: $(if ($SkipPublicDataWorker) { "skipped" } else { "enabled" })"
+}
+
+if ($CheckOnly) {
+  Write-Host ""
+  Write-Host "Planned smoke checks:"
+  Write-Host "  agent-health"
+  Write-Host "  router-health"
+  Write-Host "  classifier-health"
+  if (-not $SkipPublicDataWorker) {
+    Write-Host "  legacy-worker-absent"
+    Write-Host "  public-data-worker-running"
+    Write-Host "  public-data-worker-doctor"
+    Write-Host "  public-data-worker-schedule-dry-run"
+  }
+  Write-Host ""
+  Write-Host "Check-only completed. No smoke test artifacts were created."
+  exit 0
+}
+
+$script:StartedAt = (Get-Date).ToUniversalTime()
+$script:Checks = [System.Collections.ArrayList]::new()
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$script:RunRoot = Join-Path $OutputRootPath $timestamp
+$status = "running"
+$errorMessage = $null
+
+New-Item -ItemType Directory -Force -Path $script:RunRoot | Out-Null
+
+try {
+  Invoke-Step "Checking Docker state" {
+    Assert-Command -Name "docker"
+    Assert-DockerDaemon
+  }
+
+  Invoke-Step "Checking service health" {
+    Invoke-SmokeCheck -Name "agent-health" -Arguments @("exec", "mjuclaw-agent", "curl", "-fsS", "--max-time", "5", "http://localhost:3001/health")
+    Invoke-SmokeCheck -Name "router-health" -Arguments @("exec", "mjuclaw-router", "curl", "-fsS", "--max-time", "5", "http://localhost:3100/healthz")
+    Invoke-SmokeCheck -Name "classifier-health" -Arguments @("exec", "mjuclaw-classifier", "curl", "-fsS", "--max-time", "5", "http://localhost:3200/healthz")
+  }
+
+  if (-not $SkipPublicDataWorker) {
+    Invoke-Step "Checking public data worker" {
+      Invoke-LegacyWorkerAbsentCheck
+      Invoke-ContainerRunningCheck -Name "public-data-worker-running" -Container "mjuclaw-public-data-worker"
+      Invoke-SmokeCheck -Name "public-data-worker-doctor" -Arguments @("exec", "mjuclaw-public-data-worker", "node", "dist/main.js", "doctor")
+      Invoke-SmokeCheck -Name "public-data-worker-schedule-dry-run" -Arguments @("exec", "mjuclaw-public-data-worker", "node", "dist/main.js", "schedule", "tick", "--dry-run")
+    }
+  }
+
+  $status = "succeeded"
+}
+catch {
+  $status = "failed"
+  $errorMessage = $_.Exception.Message
+  Write-Host ""
+  Write-Host "Smoke test failed: $errorMessage" -ForegroundColor Red
+}
+finally {
+  Write-SmokeRecord -Status $status -ErrorMessage $errorMessage
+}
+
+if ($status -ne "succeeded") {
+  exit 1
+}
+
+Write-Host ""
+Write-Host "Smoke test completed."

--- a/test/smoke-test-script.test.cjs
+++ b/test/smoke-test-script.test.cjs
@@ -1,0 +1,174 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const repoRoot = path.resolve(__dirname, "..");
+const smokeScript = path.join(repoRoot, "smoke-test.ps1");
+
+function createFakeDocker(tempDir) {
+  const fakeBin = path.join(tempDir, "bin");
+  fs.mkdirSync(fakeBin, { recursive: true });
+
+  const dockerJs = path.join(fakeBin, "docker.js");
+  const logPath = path.join(tempDir, "docker-calls.jsonl");
+  fs.writeFileSync(
+    dockerJs,
+    `
+const fs = require("node:fs");
+const logPath = ${JSON.stringify(logPath)};
+const args = process.argv.slice(2);
+fs.appendFileSync(logPath, JSON.stringify(args) + "\\n");
+
+function hasAll(values) {
+  return values.every((value) => args.includes(value));
+}
+
+if (args[0] === "version") {
+  console.log("25.0.0");
+  process.exit(0);
+}
+
+if (args[0] === "inspect" && args[1] === "-f") {
+  const name = args[args.length - 1];
+  const running = new Set([
+    "mjuclaw-agent",
+    "mjuclaw-router",
+    "mjuclaw-classifier",
+    "mjuclaw-public-data-worker",
+  ]);
+  if (running.has(name)) {
+    console.log("true");
+    process.exit(0);
+  }
+  process.exit(1);
+}
+
+if (args[0] === "inspect" && args[1] === "mjuclaw-worker") {
+  process.exit(1);
+}
+
+if (args[0] === "exec" && hasAll(["curl"])) {
+  console.log("{\\"ok\\":true}");
+  process.exit(0);
+}
+
+if (args[0] === "exec" && args[1] === "mjuclaw-public-data-worker" && hasAll(["doctor"])) {
+  console.log("doctor ok");
+  process.exit(0);
+}
+
+if (args[0] === "exec" && args[1] === "mjuclaw-public-data-worker" && hasAll(["schedule", "tick", "--dry-run"])) {
+  console.log("schedule dry-run ok");
+  process.exit(0);
+}
+
+console.error("unexpected docker args: " + JSON.stringify(args));
+process.exit(1);
+`,
+    "utf8"
+  );
+
+  fs.writeFileSync(
+    path.join(fakeBin, "docker.cmd"),
+    `@echo off\r\nnode "%~dp0\\docker.js" %*\r\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(fakeBin, "docker"),
+    `#!/bin/sh\nnode "$(dirname "$0")/docker.js" "$@"\n`,
+    { encoding: "utf8", mode: 0o755 }
+  );
+
+  return { fakeBin, logPath };
+}
+
+function runSmoke(args, tempDir) {
+  const { fakeBin, logPath } = createFakeDocker(tempDir);
+  const env = {
+    ...process.env,
+    PATH: `${fakeBin}${path.delimiter}${process.env.PATH}`,
+  };
+
+  const candidates =
+    process.platform === "win32"
+      ? ["pwsh", "powershell"]
+      : ["pwsh"];
+
+  let result;
+  for (const command of candidates) {
+    result = spawnSync(
+      command,
+      ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", smokeScript, ...args],
+      { cwd: repoRoot, env, encoding: "utf8" }
+    );
+    if (result.error?.code !== "ENOENT") {
+      break;
+    }
+  }
+
+  return { result, logPath };
+}
+
+function readDockerCalls(logPath) {
+  if (!fs.existsSync(logPath)) {
+    return [];
+  }
+
+  return fs
+    .readFileSync(logPath, "utf8")
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+test("smoke-test check-only prints the plan without creating artifacts or calling docker", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mjuclaw-smoke-check-"));
+  const outputRoot = path.join(tempDir, "smoke-tests");
+
+  const { result, logPath } = runSmoke(["-CheckOnly", "-OutputRoot", outputRoot], tempDir);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Check-only completed/);
+  assert.equal(fs.existsSync(outputRoot), false);
+  assert.deepEqual(readDockerCalls(logPath), []);
+});
+
+test("smoke-test records service health and public data worker checks", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mjuclaw-smoke-run-"));
+  const outputRoot = path.join(tempDir, "smoke-tests");
+
+  const { result, logPath } = runSmoke(["-OutputRoot", outputRoot], tempDir);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Smoke test record:/);
+
+  const runs = fs.readdirSync(outputRoot);
+  assert.equal(runs.length, 1);
+
+  const recordPath = path.join(outputRoot, runs[0], "smoke-test.json");
+  const record = JSON.parse(fs.readFileSync(recordPath, "utf8").replace(/^\uFEFF/, ""));
+
+  assert.equal(record.status, "succeeded");
+  assert.deepEqual(
+    record.checks.map((check) => check.name),
+    [
+      "agent-health",
+      "router-health",
+      "classifier-health",
+      "legacy-worker-absent",
+      "public-data-worker-running",
+      "public-data-worker-doctor",
+      "public-data-worker-schedule-dry-run",
+    ]
+  );
+  assert.equal(record.checks.every((check) => check.status === "succeeded"), true);
+
+  const calls = readDockerCalls(logPath);
+  assert.equal(calls.some((args) => args.includes("mjuclaw-agent") && args.includes("curl")), true);
+  assert.equal(calls.some((args) => args.includes("mjuclaw-public-data-worker") && args.includes("doctor")), true);
+  assert.equal(calls.some((args) => args.includes("mjuclaw-public-data-worker") && args.includes("--dry-run")), true);
+});


### PR DESCRIPTION
## 요약
- 배포 후 운영 검증을 표준화하는 `smoke-test.ps1`를 추가했습니다.
- agent/router/classifier health, legacy worker 부재, public data worker 실행/doctor/schedule dry-run을 검증합니다.
- 결과를 `.deploy/smoke-tests/<timestamp>/smoke-test.json`에 기록하고 실패 시 non-zero exit로 종료합니다.
- CI에 smoke script syntax, argument validation, check-only 검증을 추가했습니다.
- `DEPLOYMENT.md`의 smoke test 절차를 helper 기준으로 갱신했습니다.

## 검증
- `node --test test/smoke-test-script.test.cjs`
- `.\smoke-test.ps1 -CheckOnly -OutputRoot .tmp/smoke-tests`
- `.\smoke-test.ps1`
- `git diff --check`
- YAML parse
- `npm test`

## Post-Deploy Monitoring & Validation
- 배포 후 `.\smoke-test.ps1`를 실행해 `.deploy/smoke-tests/<timestamp>/smoke-test.json`의 `status: succeeded`를 확인합니다.
- 실패 신호: service health 실패, `mjuclaw-worker` 잔존, public data worker doctor/schedule dry-run 실패.
- 실패 시 최신 `deploy.json`, smoke-test 기록, 관련 container logs를 확인하고 필요하면 기존 rollback 절차를 사용합니다.
- Discord/LLM 실제 대화 smoke는 side effect가 있어 아직 수동 확인으로 유지합니다.