### PR TITLE
ops: main push production dry-run 자동화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,54 @@ jobs:
             exit 1
           fi
 
+      - name: Validate production dry-run workflow safety
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow=".github/workflows/production-dry-run.yml"
+          test -f "$workflow"
+          grep -q "push:" "$workflow"
+          grep -q "branches:" "$workflow"
+          grep -q "main" "$workflow"
+          grep -q "workflow_dispatch:" "$workflow"
+          grep -q "mjuclaw-prod-windows" "$workflow"
+          grep -q "prepare-release.ps1 -CheckOnly" "$workflow"
+          grep -q "deploy.ps1 -CheckOnly" "$workflow"
+          grep -q "backup.ps1 -CheckOnly" "$workflow"
+          grep -q "smoke-test.ps1 -CheckOnly" "$workflow"
+          if grep -q "pull_request:" "$workflow"; then
+            echo "production dry-run workflow must not run on pull_request"
+            exit 1
+          fi
+          if grep -q "environment:" "$workflow"; then
+            echo "production dry-run workflow must not require environment approval"
+            exit 1
+          fi
+          if grep -q "actions/checkout" "$workflow"; then
+            echo "production dry-run workflow must use the fixed production checkout"
+            exit 1
+          fi
+          if grep -q "prepare-release.ps1 -Apply" "$workflow"; then
+            echo "production dry-run workflow must not apply release candidates"
+            exit 1
+          fi
+          if grep -q "deploy.ps1 -PullOnly" "$workflow"; then
+            echo "production dry-run workflow must not pull images"
+            exit 1
+          fi
+          if grep -q "deploy.ps1 -RollbackOnFailure" "$workflow"; then
+            echo "production dry-run workflow must not deploy or rollback"
+            exit 1
+          fi
+          if grep -Eq '^[[:space:]]*\\.\\backup\\.ps1[[:space:]]*$' "$workflow"; then
+            echo "production dry-run workflow must not create backups"
+            exit 1
+          fi
+          if grep -Eq '^[[:space:]]*\\.\\smoke-test\\.ps1[[:space:]]*$' "$workflow"; then
+            echo "production dry-run workflow must not run real smoke tests"
+            exit 1
+          fi
+
   deploy-script-windows:
     name: Deploy script Windows checks
     runs-on: windows-latest

--- a/.github/workflows/production-dry-run.yml
+++ b/.github/workflows/production-dry-run.yml
@@ -1,0 +1,101 @@
+name: Production Dry Run
+run-name: Production Dry Run (${{ github.ref_name }})
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-dry-run
+  cancel-in-progress: true
+
+jobs:
+  dry-run:
+    name: Production dry run
+    runs-on: [self-hosted, Windows, mjuclaw-prod-windows]
+    timeout-minutes: 10
+
+    env:
+      DEPLOY_WORKDIR: 'C:\Users\yoonh\Desktop\mjuclaw-setup'
+
+    steps:
+      - name: Guard main branch only
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ("${{ github.ref }}" -ne "refs/heads/main") {
+            throw "Production dry run must run from main. Current ref: ${{ github.ref }}"
+          }
+
+      - name: Show runner context
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          Write-Host "Runner: $env:RUNNER_NAME"
+          Write-Host "Machine: $env:COMPUTERNAME"
+          Write-Host "Deploy workdir: $env:DEPLOY_WORKDIR"
+          Write-Host "Event: ${{ github.event_name }}"
+
+      - name: Sync production checkout
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+
+          if (-not (Test-Path -LiteralPath $env:DEPLOY_WORKDIR -PathType Container)) {
+            throw "Production checkout not found: $env:DEPLOY_WORKDIR"
+          }
+
+          Set-Location $env:DEPLOY_WORKDIR
+
+          if (-not (Test-Path -LiteralPath ".git" -PathType Container)) {
+            throw "Production checkout is not a git repository: $env:DEPLOY_WORKDIR"
+          }
+
+          $status = git status --short
+          if ($status) {
+            $status | ForEach-Object { Write-Host $_ }
+            throw "Production checkout has uncommitted changes. Clean the checkout before running production dry run."
+          }
+
+          git fetch origin main
+          git switch main
+          git pull --ff-only origin main
+          git rev-parse --short HEAD
+
+      - name: Validate release candidate
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          Set-Location $env:DEPLOY_WORKDIR
+          .\prepare-release.ps1 -CheckOnly
+
+      - name: Validate deploy preflight
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          Set-Location $env:DEPLOY_WORKDIR
+          .\deploy.ps1 -CheckOnly
+
+      - name: Validate backup preflight
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          Set-Location $env:DEPLOY_WORKDIR
+          .\backup.ps1 -CheckOnly
+
+      - name: Validate smoke test plan
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          Set-Location $env:DEPLOY_WORKDIR
+          .\smoke-test.ps1 -CheckOnly

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -30,6 +30,7 @@
 | Self-hosted runner 운영 기준 | 완료 | 운영 PC runner 보안/실행 경계와 실제 실행 기준 문서화 |
 | Production dry-run workflow | 완료 | `workflow_dispatch` 기반 check-only workflow 추가 및 운영 PC dry-run 성공 확인 |
 | 승인 기반 production deploy workflow | 완료 | `workflow_dispatch` + production approval 기반 실제 deploy mode 운영 PC 성공 확인 |
+| Main push production dry-run | 완료 | `main` push 시 운영 PC runner에서 check-only 검증 자동 실행 |
 | 완전 자동 CD | 미완료 | main push 즉시 자동 배포는 아직 도입하지 않음 |
 
 ---
@@ -821,7 +822,8 @@ self-hosted runner는 GitHub Actions job을 운영 PC에서 실행한다. 따라
 ### 도입 원칙
 
 - 완전 자동 배포를 `main` push에 바로 연결하지 않는다.
-- 첫 workflow는 `workflow_dispatch` 수동 실행만 허용한다.
+- 실제 deploy workflow는 `workflow_dispatch` 수동 실행만 허용한다.
+- `main` push 자동화는 check-only dry-run workflow에만 허용한다.
 - `pull_request`, fork, 임의 branch code가 운영 runner에서 실행되지 않게 한다.
 - 운영 PC runner는 `mjuclaw-setup` repo 전용 repo-level runner로 제한한다.
 - workflow는 GitHub Actions workspace가 아니라 운영 PC의 고정 checkout인 `C:\Users\yoonh\Desktop\mjuclaw-setup`에서 배포 스크립트를 실행한다.
@@ -864,6 +866,8 @@ runs-on: [self-hosted, Windows, mjuclaw-prod-windows]
 
 `Production Deploy` workflow는 `workflow_dispatch` 수동 실행만 허용한다. `mode` 입력으로 `dry-run` 또는 `deploy`를 선택한다. 두 mode 모두 production environment approval과 production runner label을 사용한다.
 
+`Production Dry Run` workflow는 `main` push 또는 수동 `workflow_dispatch`로 실행된다. 이 workflow는 production environment approval을 사용하지 않는다. 대신 운영 PC runner에서 check-only 명령만 실행하고, image pull, backup 생성, compose up, 실제 smoke test, deploy, rollback은 수행하지 않는다.
+
 ### Workflow 단계 기준
 
 `dry-run` mode는 실제 배포 없이 check-only만 수행한다.
@@ -899,6 +903,30 @@ PR17 merge 후 운영 리허설 완료 기준:
 - 운영 checkout에서 최신 main을 fast-forward한다.
 - `prepare-release`, `deploy`, `backup` check-only가 통과한다.
 - `.deploy\release-candidates`, `.deploy\backups`, `.deploy\releases`에 새 산출물이 생성되지 않는다.
+
+`Production Dry Run` 자동 workflow는 `main` push마다 실제 배포 없이 check-only만 수행한다.
+
+```text
+main push
+  -> runs-on: [self-hosted, Windows, mjuclaw-prod-windows]
+  -> cd C:\Users\yoonh\Desktop\mjuclaw-setup
+  -> git fetch origin
+  -> git switch main
+  -> git pull --ff-only origin main
+  -> .\prepare-release.ps1 -CheckOnly
+  -> .\deploy.ps1 -CheckOnly
+  -> .\backup.ps1 -CheckOnly
+  -> .\smoke-test.ps1 -CheckOnly
+```
+
+자동 dry-run의 완료 기준:
+
+- `main` push 시 `Production Dry Run` workflow가 자동 실행된다.
+- production runner가 job을 수신한다.
+- 운영 checkout에서 최신 main을 fast-forward한다.
+- `prepare-release`, `deploy`, `backup`, `smoke-test` check-only가 통과한다.
+- `release.env` 적용, image pull, backup 생성, compose up, 실제 smoke test는 수행하지 않는다.
+- `.deploy\release-candidates`, `.deploy\backups`, `.deploy\releases`, `.deploy\smoke-tests`에 새 산출물이 생성되지 않는다.
 
 `deploy` mode는 승인 후 실제 배포를 수행한다.
 
@@ -981,9 +1009,9 @@ runner 도입 후 문제가 생기면 아래 순서로 반자동 운영으로 �
    - 현재 `run.cmd`로 임시 실행 중이면 Windows Service 등록을 검토한다.
    - 서비스화할 경우 재부팅 후 runner 자동 시작과 Docker Desktop 접근 권한을 확인한다.
 
-2. main push 자동 dry-run 도입 검토
-   - `main` push 시 production runner에서 `prepare-release.ps1 -CheckOnly`, `deploy.ps1 -CheckOnly`, `backup.ps1 -CheckOnly`만 자동 실행할지 결정한다.
-   - 이 단계에서는 image pull, backup 생성, compose up, smoke test는 수행하지 않는다.
+2. main push approval-gated deploy 도입 검토
+   - `main` push가 deploy workflow를 자동 시작하되, production approval 이후에만 실제 deploy를 수행할지 결정한다.
+   - approval 없는 즉시 deploy로 넘어가기 전 중간 단계로 검토한다.
 
 3. main push 즉시 자동 배포는 계속 보류
    - 승인 기반 `workflow_dispatch` 운영을 기본으로 유지한다.


### PR DESCRIPTION
## 요약
- `main` push 시 운영 PC self-hosted runner에서 자동으로 check-only dry-run을 실행하는 `Production Dry Run` workflow를 추가했습니다.
- 자동 dry-run은 release 적용, image pull, backup 생성, compose up, 실제 smoke test, deploy, rollback을 수행하지 않습니다.
- CI safety check를 추가해 dry-run workflow가 check-only 경계 밖으로 나가지 않도록 검증합니다.
- `DEPLOYMENT.md`에 main push 자동 dry-run 흐름과 후속 작업을 반영했습니다.

## 검증
- `git diff --check`
- staged diff check
- YAML parse
- production deploy workflow safety check
- production dry-run workflow safety check
- `npm test`

## Post-Deploy Monitoring & Validation
- PR merge 후 `main` push로 `Production Dry Run` workflow가 자동 실행되는지 확인합니다.
- 정상 신호: 운영 PC runner가 job을 수신하고 `prepare-release`, `deploy`, `backup`, `smoke-test` check-only step이 모두 성공합니다.
- 실패 신호: runner offline/label mismatch, dirty production checkout, check-only 검증 실패.
- 이 workflow는 운영 서비스를 변경하지 않으므로 rollback은 필요 없습니다.