### PR TITLE
ops: Production Dry Run을 CI 성공 후 실행하도록 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,15 +302,27 @@ jobs:
           set -euo pipefail
           workflow=".github/workflows/production-dry-run.yml"
           test -f "$workflow"
-          grep -q "push:" "$workflow"
-          grep -q "branches:" "$workflow"
+          grep -q "workflow_run:" "$workflow"
+          grep -q "workflows:" "$workflow"
+          grep -q "CI" "$workflow"
+          grep -q "types:" "$workflow"
+          grep -q "completed" "$workflow"
           grep -q "main" "$workflow"
           grep -q "workflow_dispatch:" "$workflow"
           grep -q "mjuclaw-prod-windows" "$workflow"
+          grep -q "github.event.workflow_run.conclusion == 'success'" "$workflow"
+          grep -q "github.event.workflow_run.head_branch == 'main'" "$workflow"
+          grep -q "github.event.workflow_run.event == 'push'" "$workflow"
+          grep -q "Skipping stale production dry run" "$workflow"
+          grep -q "steps.sync.outputs.skipped != 'true'" "$workflow"
           grep -q "prepare-release.ps1 -CheckOnly" "$workflow"
           grep -q "deploy.ps1 -CheckOnly" "$workflow"
           grep -q "backup.ps1 -CheckOnly" "$workflow"
           grep -q "smoke-test.ps1 -CheckOnly" "$workflow"
+          if grep -q "push:" "$workflow"; then
+            echo "production dry-run workflow must wait for CI workflow_run instead of running directly on push"
+            exit 1
+          fi
           if grep -q "pull_request:" "$workflow"; then
             echo "production dry-run workflow must not run on pull_request"
             exit 1

--- a/.github/workflows/production-dry-run.yml
+++ b/.github/workflows/production-dry-run.yml
@@ -1,10 +1,12 @@
 name: Production Dry Run
-run-name: Production Dry Run (${{ github.ref_name }})
+run-name: Production Dry Run (${{ github.event.workflow_run.head_branch || github.ref_name }})
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -17,6 +19,13 @@ concurrency:
 jobs:
   dry-run:
     name: Production dry run
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.event == 'push'
+      )
     runs-on: [self-hosted, Windows, mjuclaw-prod-windows]
     timeout-minutes: 10
 
@@ -28,8 +37,19 @@ jobs:
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
-          if ("${{ github.ref }}" -ne "refs/heads/main") {
-            throw "Production dry run must run from main. Current ref: ${{ github.ref }}"
+          if ("${{ github.event_name }}" -eq "workflow_run") {
+            if ("${{ github.event.workflow_run.conclusion }}" -ne "success") {
+              throw "Production dry run requires a successful CI workflow. Current conclusion: ${{ github.event.workflow_run.conclusion }}"
+            }
+            if ("${{ github.event.workflow_run.head_branch }}" -ne "main") {
+              throw "Production dry run must run from main. Current branch: ${{ github.event.workflow_run.head_branch }}"
+            }
+            if ("${{ github.event.workflow_run.event }}" -ne "push") {
+              throw "Production dry run must follow a main push CI run. Current event: ${{ github.event.workflow_run.event }}"
+            }
+          }
+          elseif ("${{ github.ref }}" -ne "refs/heads/main") {
+            throw "Manual production dry run must run from main. Current ref: ${{ github.ref }}"
           }
 
       - name: Show runner context
@@ -40,8 +60,14 @@ jobs:
           Write-Host "Machine: $env:COMPUTERNAME"
           Write-Host "Deploy workdir: $env:DEPLOY_WORKDIR"
           Write-Host "Event: ${{ github.event_name }}"
+          if ("${{ github.event_name }}" -eq "workflow_run") {
+            Write-Host "CI head branch: ${{ github.event.workflow_run.head_branch }}"
+            Write-Host "CI head SHA: ${{ github.event.workflow_run.head_sha }}"
+            Write-Host "CI conclusion: ${{ github.event.workflow_run.conclusion }}"
+          }
 
       - name: Sync production checkout
+        id: sync
         shell: powershell
         run: |
           Set-StrictMode -Version Latest
@@ -64,11 +90,25 @@ jobs:
           }
 
           git fetch origin main
+
+          if ("${{ github.event_name }}" -eq "workflow_run") {
+            $expectedHead = "${{ github.event.workflow_run.head_sha }}"
+            $originMain = (git rev-parse origin/main).Trim()
+            if ($originMain -ne $expectedHead) {
+              Write-Host "Skipping stale production dry run."
+              Write-Host "CI completed for $expectedHead, but origin/main is $originMain."
+              "skipped=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+              exit 0
+            }
+          }
+
+          "skipped=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           git switch main
           git pull --ff-only origin main
           git rev-parse --short HEAD
 
       - name: Validate release candidate
+        if: steps.sync.outputs.skipped != 'true'
         shell: powershell
         run: |
           Set-StrictMode -Version Latest
@@ -77,6 +117,7 @@ jobs:
           .\prepare-release.ps1 -CheckOnly
 
       - name: Validate deploy preflight
+        if: steps.sync.outputs.skipped != 'true'
         shell: powershell
         run: |
           Set-StrictMode -Version Latest
@@ -85,6 +126,7 @@ jobs:
           .\deploy.ps1 -CheckOnly
 
       - name: Validate backup preflight
+        if: steps.sync.outputs.skipped != 'true'
         shell: powershell
         run: |
           Set-StrictMode -Version Latest
@@ -93,6 +135,7 @@ jobs:
           .\backup.ps1 -CheckOnly
 
       - name: Validate smoke test plan
+        if: steps.sync.outputs.skipped != 'true'
         shell: powershell
         run: |
           Set-StrictMode -Version Latest

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -30,7 +30,7 @@
 | Self-hosted runner 운영 기준 | 완료 | 운영 PC runner 보안/실행 경계와 실제 실행 기준 문서화 |
 | Production dry-run workflow | 완료 | `workflow_dispatch` 기반 check-only workflow 추가 및 운영 PC dry-run 성공 확인 |
 | 승인 기반 production deploy workflow | 완료 | `workflow_dispatch` + production approval 기반 실제 deploy mode 운영 PC 성공 확인 |
-| Main push production dry-run | 완료 | `main` push 시 운영 PC runner에서 check-only 검증 자동 실행 |
+| Main push production dry-run | 완료 | `main` push의 CI 성공 후 운영 PC runner에서 check-only 검증 자동 실행 |
 | 완전 자동 CD | 미완료 | main push 즉시 자동 배포는 아직 도입하지 않음 |
 
 ---
@@ -866,7 +866,7 @@ runs-on: [self-hosted, Windows, mjuclaw-prod-windows]
 
 `Production Deploy` workflow는 `workflow_dispatch` 수동 실행만 허용한다. `mode` 입력으로 `dry-run` 또는 `deploy`를 선택한다. 두 mode 모두 production environment approval과 production runner label을 사용한다.
 
-`Production Dry Run` workflow는 `main` push 또는 수동 `workflow_dispatch`로 실행된다. 이 workflow는 production environment approval을 사용하지 않는다. 대신 운영 PC runner에서 check-only 명령만 실행하고, image pull, backup 생성, compose up, 실제 smoke test, deploy, rollback은 수행하지 않는다.
+`Production Dry Run` workflow는 `main` push 자체가 아니라 `CI` workflow 성공 완료 후 또는 수동 `workflow_dispatch`로 실행된다. 같은 push에서 발행되는 `mjuclaw-agent:sha-*` image가 GHCR에 올라오기 전에 dry-run이 먼저 image tag를 검사하는 race condition을 막기 위해 `workflow_run`을 사용한다. 이 workflow는 production environment approval을 사용하지 않는다. 대신 운영 PC runner에서 check-only 명령만 실행하고, image pull, backup 생성, compose up, 실제 smoke test, deploy, rollback은 수행하지 않는다.
 
 ### Workflow 단계 기준
 
@@ -904,13 +904,17 @@ PR17 merge 후 운영 리허설 완료 기준:
 - `prepare-release`, `deploy`, `backup` check-only가 통과한다.
 - `.deploy\release-candidates`, `.deploy\backups`, `.deploy\releases`에 새 산출물이 생성되지 않는다.
 
-`Production Dry Run` 자동 workflow는 `main` push마다 실제 배포 없이 check-only만 수행한다.
+`Production Dry Run` 자동 workflow는 `main` push의 `CI` workflow가 성공한 뒤 실제 배포 없이 check-only만 수행한다.
 
 ```text
 main push
+  -> CI
+  -> Agent Docker build and publish
+  -> Production Dry Run workflow_run
   -> runs-on: [self-hosted, Windows, mjuclaw-prod-windows]
   -> cd C:\Users\yoonh\Desktop\mjuclaw-setup
   -> git fetch origin
+  -> workflow_run head_sha가 현재 origin/main인지 확인
   -> git switch main
   -> git pull --ff-only origin main
   -> .\prepare-release.ps1 -CheckOnly
@@ -921,8 +925,9 @@ main push
 
 자동 dry-run의 완료 기준:
 
-- `main` push 시 `Production Dry Run` workflow가 자동 실행된다.
+- `main` push의 `CI` workflow가 성공한 뒤 `Production Dry Run` workflow가 자동 실행된다.
 - production runner가 job을 수신한다.
+- CI 완료 이벤트의 `head_sha`가 현재 `origin/main`과 다르면 오래된 dry-run으로 보고 검증 단계를 건너뛴다.
 - 운영 checkout에서 최신 main을 fast-forward한다.
 - `prepare-release`, `deploy`, `backup`, `smoke-test` check-only가 통과한다.
 - `release.env` 적용, image pull, backup 생성, compose up, 실제 smoke test는 수행하지 않는다.


### PR DESCRIPTION
## 요약

- `Production Dry Run` workflow를 `main push` 직접 트리거에서 `CI` workflow 성공 후 `workflow_run` 트리거로 변경했습니다.
- 같은 main push에서 생성되는 `mjuclaw-agent:sha-*` 이미지가 GHCR에 publish되기 전에 dry-run이 먼저 실행되는 race condition을 방지합니다.
- 오래된 CI 완료 이벤트가 뒤늦게 들어온 경우, 해당 `head_sha`가 현재 `origin/main`과 다르면 stale dry-run으로 보고 검증 단계를 건너뜁니다.
- CI safety check와 배포 문서를 변경된 실행 순서에 맞게 업데이트했습니다.

## 검증

- `npm test`
- workflow YAML 파싱
- `production-dry-run.yml` safety check 로컬 재현
- `git diff --check`