### PR TITLE
fix: Gemini Flash-Lite 모델 보정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # ── Discord / AI ───────────────────────────────────────────────
 DISCORD_BOT_TOKEN=your_discord_bot_token
 GEMINI_API_KEY=your_gemini_api_key
-OPENCLAW_MODEL=gemini-3.1-flash-lite-preview
+OPENCLAW_MODEL=gemini-3.1-flash-lite
 DISCORD_SERVER_ID=1492100109997969499
 DISCORD_USER_ID=415349075274104832
 VIEW_PORT=3001

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ mju-news/
 mjuclaw-router/
 intent-classifier/
 mju-public-data-worker/
+mjuclaw-agent/
 .tmp/
 tmp/
 output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # OpenClaw CLI 설치
 RUN npm install -g openclaw@2026.4.11
 
+# OpenClaw 2026.4.11 normalizes gemini-3.1-flash-lite to the deprecated
+# preview id internally. Patch the installed runtime so deployment env can use
+# the current Gemini model id until upstream removes that mapping.
+RUN python3 - <<'PY'
+from pathlib import Path
+
+root = Path("/usr/local/lib/node_modules/openclaw")
+targets = [
+    root / "dist",
+    root / "node_modules/@mariozechner/pi-ai/dist",
+]
+old = "gemini-3.1-flash-lite-preview"
+new = "gemini-3.1-flash-lite"
+
+for target in targets:
+    for path in target.rglob("*"):
+        if not path.is_file() or path.suffix not in {".js", ".mjs", ".map", ".d.ts"}:
+            continue
+        text = path.read_text(errors="ignore")
+        if old not in text:
+            continue
+        path.write_text(text.replace(old, new))
+PY
+
 # 작업 유저 생성
 RUN groupadd -r agent && useradd -r -g agent -m -d /home/agent agent
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,7 +10,7 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       - GEMINI_API_KEY=${GEMINI_API_KEY}
-      - OPENCLAW_MODEL=${OPENCLAW_MODEL:-gemini-3.1-flash-lite-preview}
+      - OPENCLAW_MODEL=${OPENCLAW_MODEL:-gemini-3.1-flash-lite}
       - DISCORD_SERVER_ID=${DISCORD_SERVER_ID:-1492100109997969499}
       - DISCORD_USER_ID=${DISCORD_USER_ID:-415349075274104832}
       - VIEW_PORT=${VIEW_PORT:-3001}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # 직접 들어가 LLM이 잘못된 사용자 데이터로 응답하는 사고가 발생한다
       # (2026-05-03 운영 데이터 누출 사고). entrypoint.sh가 set이면 abort한다.
       - GEMINI_API_KEY=${GEMINI_API_KEY}
-      - OPENCLAW_MODEL=${OPENCLAW_MODEL:-gemini-3.1-flash-lite-preview}
+      - OPENCLAW_MODEL=${OPENCLAW_MODEL:-gemini-3.1-flash-lite}
       - DISCORD_SERVER_ID=${DISCORD_SERVER_ID:-1492100109997969499}
       - DISCORD_USER_ID=${DISCORD_USER_ID:-415349075274104832}
       - VIEW_PORT=${VIEW_PORT:-3001}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,8 @@ DISCORD_USER_ID="${DISCORD_USER_ID:-415349075274104832}"
 # v4: channels.discord.enabled=False — Discord WS 단독 소유는 mjuclaw-router로 이전.
 # v5: channels.discord 항목 자체 제거 (enabled=False만으로는 sidecar가 어떤 경로로
 #     connect 시도해 데이터 누출 가능. agent는 토큰 자체를 받지 않는다).
-CONFIG_SCHEMA_VERSION="5"
+# v6: openclaw doctor가 생성하는 main agent model catalog도 OPENCLAW_MODEL로 보정.
+CONFIG_SCHEMA_VERSION="6"
 CONFIG_PATH="/home/agent/.openclaw/openclaw.json"
 VERSION_MARKER="/home/agent/.openclaw/.mjuclaw-schema-version"
 CONFIG_INPUTS_MARKER="/home/agent/.openclaw/.mjuclaw-config-inputs.json"
@@ -220,6 +221,85 @@ done
 # ── 초기 doctor 실행 ────────────────────────────────────────────
 openclaw doctor --fix > /dev/null 2>&1 || true
 
+# openclaw doctor는 ~/.openclaw/openclaw.json과 별개로 main agent의 model
+# catalog를 생성한다. 이 파일에 예전 preview id가 남으면 gateway가 env/config가
+# 아니라 catalog id를 우선 선택해 deprecated model을 호출한다.
+python3 <<'PYEOF'
+import json
+import os
+from pathlib import Path
+
+model = os.environ.get("OPENCLAW_MODEL", "gemini-2.5-flash")
+path = Path("/home/agent/.openclaw/agents/main/agent/models.json")
+path.parent.mkdir(parents=True, exist_ok=True)
+
+if path.exists():
+    data = json.loads(path.read_text())
+else:
+    data = {}
+providers = data.setdefault("providers", {})
+google = providers.setdefault("google", {})
+google["baseUrl"] = "https://generativelanguage.googleapis.com/v1beta"
+google["api"] = "google-generative-ai"
+models = google.setdefault("models", [])
+if not models:
+    models.append({})
+
+models[0].update(
+    {
+        "id": model,
+        "name": "google/" + model,
+        "reasoning": False,
+        "input": ["text"],
+        "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+        "contextWindow": 1048576,
+        "maxTokens": 8192,
+        "api": "google-generative-ai",
+    }
+)
+
+tmp = path.with_suffix(path.suffix + ".tmp")
+tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+os.chmod(tmp, 0o600)
+tmp.replace(path)
+
+# OpenClaw는 기존 session index에 저장된 model 값을 gateway 시작 시 다시 반영한다.
+# 그래서 catalog만 고치면 오래된 세션이 deprecated preview id를 되살릴 수 있다.
+old_model_values = {
+    "gemini-3.1-flash-lite-preview",
+    "google/gemini-3.1-flash-lite-preview",
+}
+sessions_path = Path("/home/agent/.openclaw/agents/main/sessions/sessions.json")
+
+
+def replace_old_model_values(value):
+    if isinstance(value, dict):
+        changed = False
+        for key, child in list(value.items()):
+            if key == "model" and isinstance(child, str) and child in old_model_values:
+                value[key] = "google/" + model if child.startswith("google/") else model
+                changed = True
+            else:
+                child_changed = replace_old_model_values(child)
+                changed = changed or child_changed
+        return changed
+    if isinstance(value, list):
+        changed = False
+        for child in value:
+            changed = replace_old_model_values(child) or changed
+        return changed
+    return False
+
+
+if sessions_path.exists():
+    sessions = json.loads(sessions_path.read_text())
+    if replace_old_model_values(sessions):
+        tmp = sessions_path.with_suffix(sessions_path.suffix + ".tmp")
+        tmp.write_text(json.dumps(sessions, indent=2), encoding="utf-8")
+        os.chmod(tmp, 0o600)
+        tmp.replace(sessions_path)
+PYEOF
+
 # ── 구 mju-news-scrape cron 제거 ─────────────────────────────────
 # v2.0.0에서 스크래핑 책임은 호스트의 mju-public-data-worker가 가져갔다.
 # 예전 버전 위에서 업그레이드한 설치본이면 남아있을 수 있으므로 정리한다.
@@ -302,7 +382,7 @@ attendance_backfill() {
     [[ "$discord_id" =~ ^[0-9]{17,20}$ ]] || continue
     # vault에 크리덴셜 있는지로 "온보딩 완료" 판정
     vault_any=("$user_dir"vault/*.enc)
-    [ -e "${vault_any[0]}" ] || continue
+    [ "${#vault_any[@]}" -gt 0 ] || continue
 
     status_out=$(mju-attendance-alert status "$discord_id" 2>/dev/null || printf '%s' '{"enabled":false}')
     if printf '%s' "$status_out" | grep -q '"courses"'; then


### PR DESCRIPTION
OpenClaw 2026.4.11이 gemini-3.1-flash-lite를 deprecated preview id로 되돌리는 문제를 막기 위해 빌드 및 entrypoint 단계에서 model catalog와 session index를 보정한다.

운영 checkout clean 상태를 유지하도록 nested mjuclaw-agent repo도 ignore 목록에 추가한다.