### PR TITLE
[codex] Treat staff cafeteria as Bangmok alias

### DIFF
--- a/src/view-renderer.ts
+++ b/src/view-renderer.ts
@@ -7660,8 +7660,8 @@ type CafeteriaSource = {
 const CAFETERIA_SOURCES: CafeteriaSource[] = [
   { key: "student-hall", label: "학생회관", aliases: ["student", "student-cafeteria", "학생회관"] },
   { key: "myeongjindang", label: "명진당", aliases: ["myeongjin", "myeongjindang", "명진당"] },
-  { key: "faculty", label: "교직원", aliases: ["faculty", "faculty-cafeteria", "교직원"] },
   { key: "welfare", label: "복지동", aliases: ["welfare", "welfare-building", "복지동"] },
+  { key: "bangmok", label: "방목기념관", aliases: ["bangmok", "bangmok-cafeteria", "방목기념관", "방목관", "교직원", "교직원식당", "직원식당"] },
 ];
 
 function renderCafeteriaTable(data: unknown): string {

--- a/test/cafeteria-renderer.test.cjs
+++ b/test/cafeteria-renderer.test.cjs
@@ -1,0 +1,44 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { renderViewHtml } = require("../dist/view-renderer.js");
+
+const BANGMOK = "\uBC29\uBAA9\uAE30\uB150\uAD00";
+const FACULTY = "\uAD50\uC9C1\uC6D0";
+const FACULTY_CAFETERIA = "\uAD50\uC9C1\uC6D0\uC2DD\uB2F9";
+
+function cafeteriaEntry(sourceName) {
+  return {
+    id: "cafeteria-test-view",
+    dataType: "cafeteria",
+    title: "\uD559\uC2DD",
+    createdAt: new Date("2026-05-15T11:00:00.000Z").getTime(),
+    expiresAt: new Date("2026-05-15T11:30:00.000Z").getTime(),
+    rawData: {
+      items: [
+        {
+          sourceId: "bangmok",
+          sourceName,
+          serviceDate: "2026-05-15",
+          mealType: "lunch",
+          isClosed: false,
+          menuText: "\uD1A0\uB9C8\uD1A0\uC2A4\uD30C\uAC8C\uD2F0",
+          menuItems: ["\uD1A0\uB9C8\uD1A0\uC2A4\uD30C\uAC8C\uD2F0"],
+        },
+      ],
+    },
+  };
+}
+
+test("cafeteria renders bangmok without a separate faculty row", () => {
+  const html = renderViewHtml(cafeteriaEntry(BANGMOK));
+
+  assert.match(html, new RegExp(`<div class="cafeteria-place">${BANGMOK}</div>`));
+  assert.doesNotMatch(html, new RegExp(`<div class="cafeteria-place">${FACULTY}</div>`));
+});
+
+test("cafeteria maps faculty cafeteria aliases to bangmok", () => {
+  const html = renderViewHtml(cafeteriaEntry(FACULTY_CAFETERIA));
+
+  assert.match(html, new RegExp(`<div class="cafeteria-place">${BANGMOK}</div>`));
+  assert.doesNotMatch(html, new RegExp(`<div class="cafeteria-place">${FACULTY}</div>`));
+});


### PR DESCRIPTION
## What changed

- Removed the separate rendered staff cafeteria source from the webview source order.
- Added Bangmok/staff cafeteria labels as aliases for the Bangmok cafeteria row.
- Added regression coverage so Bangmok and staff cafeteria source names render as one Bangmok row.

## Validation

- npm run build
- node --test test\cafeteria-renderer.test.cjs
- npm test