### PR TITLE
졸업요건 요청을 졸업 로드맵으로 라우팅

### DIFF
--- a/test/msi-skill-override.test.cjs
+++ b/test/msi-skill-override.test.cjs
@@ -46,8 +46,11 @@ test("runtime instructions route academic planning away from legacy MSI and UChe
 
   assert.match(bootstrap, /시간표 설계[\s\S]*mju-news academic-planning timetable[\s\S]*timetable-planner/);
   assert.match(bootstrap, /졸업요건[\s\S]*졸업 로드맵[\s\S]*mju-news academic-planning graduation-roadmap/);
+  assert.match(bootstrap, /"내 졸업요건"[\s\S]*"졸업학점"[\s\S]*"졸업까지"[\s\S]*mju-news academic-planning graduation-roadmap/);
   assert.match(bootstrap, /일반적인 "졸업요건" 요청[\s\S]*새 졸업 로드맵/);
   assert.match(bootstrap, /MSI 원본만[\s\S]*mju msi graduation/);
+  assert.doesNotMatch(bootstrap, /\|\s*"내 졸업요건",\s*"졸업까지"\s*\|\s*`mju msi graduation`/);
+  assert.match(bootstrap, /"내 졸업요건 원본"[\s\S]*mju msi graduation/);
   assert.match(bootstrap, /시간표 설계 요청[\s\S]*mju ucheck[\s\S]*출석 웹뷰/);
   assert.match(bootstrap, /DB import[\s\S]*ucheck[\s\S]*현재 수강 시간표로 대체하지 말고/);
 

--- a/workspace/BOOTSTRAP.md
+++ b/workspace/BOOTSTRAP.md
@@ -181,7 +181,7 @@ router가 `mju-login`을 호출하면 다음이 자동으로 따라붙습니다 
 | "시간표 설계", "시간표 짜줘", "랜덤 시간표", "추천 시간표", "전공 3개 교양 2개", "요일/교시 제외", "시간 안 겹치게" | `mju-news academic-planning timetable --year <연도> --term-code <학기코드> --department "<학과>" --format json` | `timetable-planner` |
 | "내 현재 시간표", "이번 학기 수강 시간표", "지금 듣는 수업 시간표" | `mju msi timetable --app-dir /data/users/{DISCORD_USER_ID} --format json` | `timetable` |
 | "출석", "유체크", "결석", "출석 알림" | `mju ucheck lectures list --app-dir /data/users/{DISCORD_USER_ID} --format json` 또는 `mju ucheck attendance --course "<과목명>" --app-dir /data/users/{DISCORD_USER_ID} --format json` | `attendance` |
-| "졸업요건", "졸업 로드맵", "졸업까지 뭐 남았어", "내가 뭘 들었고 뭘 들어야 해", "영역별 졸업요건" | `mju-news academic-planning graduation-roadmap --department "<학과>" --format json` | `graduation` |
+| "졸업요건", "내 졸업요건", "졸업학점", "졸업 로드맵", "졸업까지", "졸업까지 뭐 남았어", "내가 뭘 들었고 뭘 들어야 해", "영역별 졸업요건" | `mju-news academic-planning graduation-roadmap --department "<학과>" --format json` | `graduation` |
 | "MSI 졸업요건 원본", "학교 시스템 졸업사정 그대로", "MSI 원본만" | `mju msi graduation --app-dir /data/users/{DISCORD_USER_ID} --format json` | `graduation` |
 
 **시간표 설계와 졸업 로드맵은 `mju-news academic-planning` 기능입니다.** 공통 DB의 개설강좌/졸업요건을 읽어 웹뷰를 만들며, 필요하면 현재 유저의 MSI 데이터로 학과/학번/입학년도/이수 과목을 보조합니다. 일반적인 "졸업요건" 요청은 기존 MSI 원본 조회가 아니라 새 졸업 로드맵으로 처리하세요. DB import가 아직 안 됐거나 결과가 비어 있어도 `ucheck`나 현재 수강 시간표로 대체하지 말고, 데이터가 아직 준비되지 않았다고 짧게 안내하세요.
@@ -198,7 +198,7 @@ router가 `mju-login`을 호출하면 다음이 자동으로 따라붙습니다 
 |---|---|---|
 | "이번 학기 성적", "현재 성적", "중간고사 점수", "기말고사 점수", "수강점수", "학기 중 점수" | `mju msi course-scores` | `course-scores` |
 | "지난 학기 성적", "전 학기 성적", "학기별 성적", "성적 이력" | `mju msi grade-history` | `grade-history` |
-| "내 졸업요건", "졸업까지" | `mju msi graduation` | `graduation` |
+| "내 졸업요건 원본", "MSI 졸업요건 그대로", "학교 시스템 졸업사정 그대로" | `mju msi graduation` | `graduation` |
 
 현재 학기 성적 관련 의도는 최종 학점/등급이 아직 없을 수 있으므로 모두 `course-scores`로 처리하세요. 기존 확정등급 조회 명령은 사용하지 않습니다.
 


### PR DESCRIPTION
## 변경 이유

일반적인 졸업요건/졸업학점/졸업까지 요청이 기존 MSI 졸업요건 웹뷰로 빠지면 새 졸업 로드맵의 개인 이수내역 + 공식 요건 매칭을 검증할 수 없습니다.

## 변경 내용

- `내 졸업요건`, `졸업학점`, `졸업까지` 표현을 academic-planning 졸업 로드맵 alias에 명시했습니다.
- legacy `mju msi graduation` 매핑은 `MSI 원본`/`학교 시스템 그대로` 요청으로만 남겼습니다.
- 동일 충돌이 재발하면 실패하는 회귀 테스트를 추가했습니다.

## 검증

- `npm.cmd test`
