### PR TITLE
졸업로드맵만 사용자-facing 졸업 웹뷰로 노출

### DIFF
--- a/bin/mju
+++ b/bin/mju
@@ -9,7 +9,7 @@
 #   msi timetable      → timetable
 #   msi course-scores  → course-scores
 #   msi grade-history  → grade-history
-#   msi graduation     → graduation
+#   msi graduation     → disabled while graduation roadmap is the only user-facing graduation view
 #   ucheck ...         → attendance
 #   그 외              → generic
 #
@@ -64,7 +64,6 @@ detect_datatype() {
     *"msi timetable"*) echo "timetable" ;;
     *"msi course-scores"*) echo "course-scores" ;;
     *"msi grade-history"*) echo "grade-history" ;;
-    *"msi graduation"*) echo "graduation" ;;
     *"ucheck"*) echo "attendance" ;;
     *) echo "" ;;
   esac
@@ -78,7 +77,6 @@ title_for_datatype() {
     "timetable") echo "시간표" ;;
     "course-scores") echo "수강점수" ;;
     "grade-history") echo "학기별 성적" ;;
-    "graduation") echo "졸업요건" ;;
     "attendance") echo "출석" ;;
     *) echo "학사 데이터" ;;
   esac

--- a/bin/mju-news
+++ b/bin/mju-news
@@ -7,7 +7,7 @@
 #   notices get <id>         → news-detail
 #   cafeterias today/week    → cafeteria
 #   course-catalog list      → timetable-planner
-#   graduation-requirements list → graduation
+#   graduation-requirements list → disabled while graduation roadmap is the only user-facing graduation view
 #   academic-planning timetable → timetable-planner
 #   academic-planning graduation-roadmap → graduation
 #   doctor / skills          → viewUrl 없음 (조회 대상 아님)
@@ -29,7 +29,6 @@ detect_datatype() {
     *"notices get"*) echo "news-detail" ;;
     *"cafeterias today"*|*"cafeterias week"*) echo "cafeteria" ;;
     *"course-catalog list"*) echo "timetable-planner" ;;
-    *"graduation-requirements list"*) echo "graduation" ;;
     *"academic-planning timetable"*) echo "timetable-planner" ;;
     *"academic-planning graduation-roadmap"*) echo "graduation" ;;
     *) echo "" ;;
@@ -42,7 +41,6 @@ should_view() {
     *"notices recent"*|*"notices search"*|*"notices get"*) return 0 ;;
     *"cafeterias today"*|*"cafeterias week"*) return 0 ;;
     *"course-catalog list"*) return 0 ;;
-    *"graduation-requirements list"*) return 0 ;;
     *"academic-planning timetable"*) return 0 ;;
     *"academic-planning graduation-roadmap"*) return 0 ;;
     *) return 1 ;;

--- a/skills/getting-mju-news/SKILL.md
+++ b/skills/getting-mju-news/SKILL.md
@@ -19,7 +19,7 @@ metadata:
 
 - 현재 내가 수강 중인 시간표 조회: `mju-msi`의 `mju msi timetable`
 - 출석/결석/UCheck 조회: `mju-ucheck` 또는 `mju ucheck ...`
-- MSI 원본 졸업요건 조회: 사용자가 "MSI 원본", "학교 시스템 그대로"를 명시한 경우에만 `mju-msi`의 `mju msi graduation`
+- MSI 원본 졸업요건 조회: 임시 비활성화. 사용자가 "MSI 원본", "학교 시스템 그대로"를 명시해도 `mju msi graduation`을 사용하지 말고 이 skill의 졸업 로드맵으로 처리
 - 시간표 설계/랜덤 시간표/추천 시간표: 이 skill의 `mju-news academic-planning timetable`
 - 졸업요건/졸업 로드맵/뭐 들었고 뭐 남았는지/영역별 공식 요건 판정: 이 skill의 `mju-news academic-planning graduation-roadmap`
 
@@ -69,7 +69,7 @@ mju-news academic-planning graduation-roadmap \
   --format json
 ```
 
-결과 JSON의 `viewUrl`을 그대로 마스킹 링크로 전달합니다. 정상 웹뷰 제목은 `졸업 로드맵`입니다. 일반적인 "졸업요건" 요청도 이 기능으로 처리합니다. 기존 `mju msi graduation`으로 열리는 `졸업요건` 웹뷰는 명시적인 MSI 원본 조회용이며, 학점 요약 중심이라 공식 과목 단위 상세가 없을 수 있습니다.
+결과 JSON의 `viewUrl`을 그대로 마스킹 링크로 전달합니다. 정상 웹뷰 제목은 `졸업 로드맵`입니다. 일반적인 "졸업요건" 요청도 이 기능으로 처리합니다. 기존 `mju msi graduation`으로 열리는 `졸업요건` 웹뷰는 임시 비활성화 상태이며, 사용자에게 노출하지 않습니다.
 
 ## 공지 / 학식
 

--- a/skills/mju-msi/SKILL.md
+++ b/skills/mju-msi/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mju-msi
 version: 1.1.0
-description: "현재 수강 시간표, 현재 학기 수강점수, 성적 이력, MSI 원본 졸업요건, 강의평가를 다루는 MSI skill."
+description: "현재 수강 시간표, 현재 학기 수강점수, 성적 이력, 강의평가를 다루는 MSI skill."
 metadata:
   openclaw:
     category: "service"
@@ -25,8 +25,7 @@ metadata:
   - 선택 옵션: `--year <연도> --term-code <학기코드>`
 - 전체 성적 이력: `mju --app-dir /data/users/<DISCORD_USER_ID> --format json msi grade-history`
   - "지난 학기 성적", "성적 이력", "누적 평점" 요청에 사용합니다.
-- MSI 원본 졸업요건 조회: `mju --app-dir /data/users/<DISCORD_USER_ID> --format json msi graduation`
-  - 사용자가 "MSI 원본", "학교 시스템 그대로"처럼 원본 조회를 명시한 경우에만 사용합니다.
+- MSI 원본 졸업요건 조회: 임시 비활성화 상태입니다. `mju msi graduation`을 사용자-facing 응답에 사용하지 말고, `getting-mju-news`의 졸업 로드맵을 사용합니다.
 - 강의평가 대상 조회: `mju --app-dir /data/users/<DISCORD_USER_ID> --format json msi lecture-evaluations list`
 - 강의평가 미리보기: `mju --app-dir /data/users/<DISCORD_USER_ID> --format json msi lecture-evaluations preview --instruction "보통으로 ㄱㄱ"`
   - 대상이 여러 개면 `--target <id-or-title>` 또는 `--all` 이 필요합니다.
@@ -43,4 +42,4 @@ metadata:
 - 시간표 설계, 랜덤 시간표, 추천 시간표, 전공/교양 개수 조합, 요일/교시 제외
 - 졸업요건, 졸업 로드맵, 졸업까지 남은 것, 들은 과목과 들어야 할 과목, 영역별 공식 요건 판정
 
-이 경우 `mju msi timetable`, `mju msi graduation`, `mju ucheck`를 사용하지 마세요. 일반적인 "졸업요건" 요청도 새 졸업 로드맵으로 대체합니다. 기존 MSI 명령은 이미 신청된 현재 상태나 학교 시스템 원본 요약을 명시적으로 조회할 때만 사용합니다.
+이 경우 `mju msi timetable`, `mju msi graduation`, `mju ucheck`를 사용하지 마세요. 일반적인 "졸업요건" 요청과 명시적인 원본 요청 모두 새 졸업 로드맵으로 대체합니다. 기존 MSI 졸업요건 명령은 임시 비활성화 상태입니다.

--- a/src/view-renderer.ts
+++ b/src/view-renderer.ts
@@ -18,7 +18,7 @@ const DATA_TYPE_META: Record<string, { kicker: string; detail: string }> = {
   "course-scores": { kicker: "COURSE SCORES", detail: "수강점수" },
   grades: { kicker: "GRADES", detail: "성적" },
   "grade-history": { kicker: "GRADE HISTORY", detail: "학기별 성적" },
-  graduation: { kicker: "졸업요건", detail: "졸업요건" },
+  graduation: { kicker: "졸업 로드맵", detail: "공식 요건 기반 로드맵" },
   "action-items": { kicker: "TODAY'S BRIEFING", detail: "지금 할 일" },
   unsubmitted: { kicker: "ASSIGNMENTS", detail: "미제출 과제" },
   "unread-notices": { kicker: "NOTICES", detail: "LMS 공지" },

--- a/test/graduation-renderer.test.cjs
+++ b/test/graduation-renderer.test.cjs
@@ -105,6 +105,13 @@ test("graduation keeps the total ring and inserts shortages before expandable ar
   assert.match(bodyHtml, /Free Elective/);
 });
 
+test("graduation chrome labels the shared view as the roadmap", () => {
+  const html = renderViewHtml(graduationEntry());
+
+  assert.match(html, /<span class="kicker">졸업 로드맵<\/span>/);
+  assert.match(html, /<div class="hero-eyebrow">공식 요건 기반 로드맵<\/div>/);
+});
+
 test("graduation keeps 0 of 0 credit meta but uses a neutral empty detail", () => {
   const creditLabel = "\uD559\uC810";
   const neutralEmpty = "\uC120\uD0DD \uC774\uC218 \uACFC\uC815\uC774\uB77C \uD604\uC7AC \uD45C\uC2DC\uD560 \uC138\uBD80 \uACFC\uBAA9\uC774 \uC5C6\uC2B5\uB2C8\uB2E4.";

--- a/test/mju-news-wrapper-academic-planning.test.cjs
+++ b/test/mju-news-wrapper-academic-planning.test.cjs
@@ -133,7 +133,7 @@ bashTest("mju-news wrapper routes course catalog reads to the timetable planner 
   assert.equal(output.viewUrl, "http://view.local/timetable-planner");
 });
 
-bashTest("mju-news wrapper routes official graduation requirements to the graduation webview", async (t) => {
+bashTest("mju-news wrapper leaves standalone graduation requirements unviewed", async (t) => {
   const fixture = await createWrapperFixture(t, {
     total: 1,
     items: [{
@@ -158,13 +158,11 @@ bashTest("mju-news wrapper routes official graduation requirements to the gradua
   ])], { cwd: fixture.root });
 
   assert.equal(result.status, 0, result.stderr);
-  const requestBody = JSON.parse(await fs.readFile(fixture.curlCapture, "utf8"));
-  assert.equal(requestBody.dataType, "graduation");
-  assert.equal(requestBody.title, "졸업 로드맵");
-  assert.equal(requestBody.rawData.items[0].rules[0].requiredCredits, 74);
+  assert.equal(await fileExists(fixture.curlCapture), false);
 
   const output = JSON.parse(result.stdout);
-  assert.equal(output.viewUrl, "http://view.local/graduation");
+  assert.equal(output.viewUrl, undefined);
+  assert.equal(output.items[0].rules[0].requiredCredits, 74);
 });
 
 bashTest("mju-news wrapper routes academic-planning timetable to the timetable planner webview", async (t) => {
@@ -232,3 +230,12 @@ bashTest("mju-news wrapper routes academic-planning graduation-roadmap to the gr
   const output = JSON.parse(result.stdout);
   assert.equal(output.viewUrl, "http://view.local/academic-graduation");
 });
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/test/mju-wrapper-course-scores.test.cjs
+++ b/test/mju-wrapper-course-scores.test.cjs
@@ -136,7 +136,7 @@ bashTest("mju wrapper routes course-scores to the view API and injects viewUrl",
   assert.equal(output.courses[0].title, "0752 - 시스템클라우드보안");
 });
 
-for (const legacyCommand of ["current-grades", "grades"]) {
+for (const legacyCommand of ["current-grades", "grades", "graduation"]) {
   bashTest(`mju wrapper leaves msi ${legacyCommand} output unviewed`, async (t) => {
     const fixture = await createWrapperFixture(t, {
       items: [{ courseTitle: "시스템클라우드보안", grade: "A+" }],

--- a/test/msi-skill-override.test.cjs
+++ b/test/msi-skill-override.test.cjs
@@ -48,9 +48,11 @@ test("runtime instructions route academic planning away from legacy MSI and UChe
   assert.match(bootstrap, /졸업요건[\s\S]*졸업 로드맵[\s\S]*mju-news academic-planning graduation-roadmap/);
   assert.match(bootstrap, /"내 졸업요건"[\s\S]*"졸업학점"[\s\S]*"졸업까지"[\s\S]*mju-news academic-planning graduation-roadmap/);
   assert.match(bootstrap, /일반적인 "졸업요건" 요청[\s\S]*새 졸업 로드맵/);
-  assert.match(bootstrap, /MSI 원본만[\s\S]*mju msi graduation/);
+  assert.match(bootstrap, /MSI 원본만[\s\S]*mju-news academic-planning graduation-roadmap/);
+  assert.match(bootstrap, /기존 MSI 졸업요건 웹뷰는 임시 비활성화/);
+  assert.doesNotMatch(bootstrap, /\|\s*"MSI 졸업요건 원본"[^|\n]*\|\s*`mju msi graduation/);
   assert.doesNotMatch(bootstrap, /\|\s*"내 졸업요건",\s*"졸업까지"\s*\|\s*`mju msi graduation`/);
-  assert.match(bootstrap, /"내 졸업요건 원본"[\s\S]*mju msi graduation/);
+  assert.doesNotMatch(bootstrap, /\|\s*"내 졸업요건 원본"[^|\n]*\|\s*`mju msi graduation`/);
   assert.match(bootstrap, /시간표 설계 요청[\s\S]*mju ucheck[\s\S]*출석 웹뷰/);
   assert.match(bootstrap, /DB import[\s\S]*ucheck[\s\S]*현재 수강 시간표로 대체하지 말고/);
 
@@ -59,15 +61,15 @@ test("runtime instructions route academic planning away from legacy MSI and UChe
   assert.match(newsSkill, /시간표 설계[\s\S]*mju-news academic-planning timetable/);
   assert.match(newsSkill, /졸업요건[\s\S]*졸업 로드맵[\s\S]*mju-news academic-planning graduation-roadmap/);
   assert.match(newsSkill, /일반적인 "졸업요건" 요청도 이 기능으로 처리/);
-  assert.match(newsSkill, /기존 `mju msi graduation`[\s\S]*명시적인 MSI 원본 조회용/);
+  assert.match(newsSkill, /기존 `mju msi graduation`[\s\S]*임시 비활성화/);
   assert.doesNotMatch(newsSkill, /mju-news list|mju-news scrape/);
 
   assert.match(msiSkill, /현재 수강 시간표 조회/);
-  assert.match(msiSkill, /MSI 원본 졸업요건 조회/);
-  assert.match(msiSkill, /원본 조회를 명시한 경우에만 사용/);
+  assert.match(msiSkill, /MSI 원본 졸업요건 조회[\s\S]*임시 비활성화/);
+  assert.doesNotMatch(msiSkill, /원본 조회를 명시한 경우에만 사용/);
   assert.match(msiSkill, /getting-mju-news[\s\S]*시간표 설계/);
   assert.match(msiSkill, /getting-mju-news[\s\S]*졸업요건[\s\S]*졸업 로드맵/);
-  assert.match(msiSkill, /일반적인 "졸업요건" 요청도 새 졸업 로드맵으로 대체/);
+  assert.match(msiSkill, /일반적인 "졸업요건" 요청과 명시적인 원본 요청 모두 새 졸업 로드맵으로 대체/);
 });
 
 test("webview wrappers keep academic planning separate from legacy MSI and UCheck views", () => {
@@ -76,13 +78,14 @@ test("webview wrappers keep academic planning separate from legacy MSI and UChec
 
   assert.match(mjuNewsWrapper, /academic-planning timetable"\*\) echo "timetable-planner"/);
   assert.match(mjuNewsWrapper, /academic-planning graduation-roadmap"\*\) echo "graduation"/);
+  assert.doesNotMatch(mjuNewsWrapper, /graduation-requirements list"\*\) echo "graduation"/);
   assert.match(mjuNewsWrapper, /"timetable-planner"\) echo "시간표 설계"/);
   assert.match(mjuNewsWrapper, /"graduation"\) echo "졸업 로드맵"/);
 
   assert.match(mjuWrapper, /msi timetable"\*\) echo "timetable"/);
-  assert.match(mjuWrapper, /msi graduation"\*\) echo "graduation"/);
+  assert.doesNotMatch(mjuWrapper, /msi graduation"\*\) echo "graduation"/);
   assert.match(mjuWrapper, /ucheck"\*\) echo "attendance"/);
-  assert.match(mjuWrapper, /"graduation"\) echo "졸업요건"/);
+  assert.doesNotMatch(mjuWrapper, /"graduation"\) echo "졸업요건"/);
   assert.match(mjuWrapper, /"attendance"\) echo "출석"/);
 });
 

--- a/workspace/BOOTSTRAP.md
+++ b/workspace/BOOTSTRAP.md
@@ -182,9 +182,9 @@ router가 `mju-login`을 호출하면 다음이 자동으로 따라붙습니다 
 | "내 현재 시간표", "이번 학기 수강 시간표", "지금 듣는 수업 시간표" | `mju msi timetable --app-dir /data/users/{DISCORD_USER_ID} --format json` | `timetable` |
 | "출석", "유체크", "결석", "출석 알림" | `mju ucheck lectures list --app-dir /data/users/{DISCORD_USER_ID} --format json` 또는 `mju ucheck attendance --course "<과목명>" --app-dir /data/users/{DISCORD_USER_ID} --format json` | `attendance` |
 | "졸업요건", "내 졸업요건", "졸업학점", "졸업 로드맵", "졸업까지", "졸업까지 뭐 남았어", "내가 뭘 들었고 뭘 들어야 해", "영역별 졸업요건" | `mju-news academic-planning graduation-roadmap --department "<학과>" --format json` | `graduation` |
-| "MSI 졸업요건 원본", "학교 시스템 졸업사정 그대로", "MSI 원본만" | `mju msi graduation --app-dir /data/users/{DISCORD_USER_ID} --format json` | `graduation` |
+| "MSI 졸업요건 원본", "학교 시스템 졸업사정 그대로", "MSI 원본만" | `mju-news academic-planning graduation-roadmap --department "<학과>" --format json` | `graduation` |
 
-**시간표 설계와 졸업 로드맵은 `mju-news academic-planning` 기능입니다.** 공통 DB의 개설강좌/졸업요건을 읽어 웹뷰를 만들며, 필요하면 현재 유저의 MSI 데이터로 학과/학번/입학년도/이수 과목을 보조합니다. 일반적인 "졸업요건" 요청은 기존 MSI 원본 조회가 아니라 새 졸업 로드맵으로 처리하세요. DB import가 아직 안 됐거나 결과가 비어 있어도 `ucheck`나 현재 수강 시간표로 대체하지 말고, 데이터가 아직 준비되지 않았다고 짧게 안내하세요.
+**시간표 설계와 졸업 로드맵은 `mju-news academic-planning` 기능입니다.** 공통 DB의 개설강좌/졸업요건을 읽어 웹뷰를 만들며, 필요하면 현재 유저의 MSI 데이터로 학과/학번/입학년도/이수 과목을 보조합니다. 기존 MSI 졸업요건 웹뷰는 임시 비활성화 상태입니다. 일반적인 "졸업요건" 요청뿐 아니라 "MSI 원본" 요청도 새 졸업 로드맵으로 처리하세요. DB import가 아직 안 됐거나 결과가 비어 있어도 `ucheck`, `mju msi graduation`, 현재 수강 시간표로 대체하지 말고, 데이터가 아직 준비되지 않았다고 짧게 안내하세요.
 
 시간표 설계 요청에서 `mju ucheck`를 호출하면 출석 웹뷰가 열립니다. "시간표"라는 단어가 있어도 설계/추천/랜덤/전공·교양 개수/요일 제외/교시 제외 맥락이면 절대 `ucheck`를 쓰지 마세요.
 
@@ -198,7 +198,7 @@ router가 `mju-login`을 호출하면 다음이 자동으로 따라붙습니다 
 |---|---|---|
 | "이번 학기 성적", "현재 성적", "중간고사 점수", "기말고사 점수", "수강점수", "학기 중 점수" | `mju msi course-scores` | `course-scores` |
 | "지난 학기 성적", "전 학기 성적", "학기별 성적", "성적 이력" | `mju msi grade-history` | `grade-history` |
-| "내 졸업요건 원본", "MSI 졸업요건 그대로", "학교 시스템 졸업사정 그대로" | `mju msi graduation` | `graduation` |
+| "내 졸업요건 원본", "MSI 졸업요건 그대로", "학교 시스템 졸업사정 그대로" | `mju-news academic-planning graduation-roadmap` | `graduation` |
 
 현재 학기 성적 관련 의도는 최종 학점/등급이 아직 없을 수 있으므로 모두 `course-scores`로 처리하세요. 기존 확정등급 조회 명령은 사용하지 않습니다.
 


### PR DESCRIPTION
## 변경 이유
기존 MSI 졸업요건/standalone 졸업요건 웹뷰가 살아 있으면 Discord에서 졸업 관련 요청이 새 졸업로드맵으로 갔는지 검증하기 어렵습니다. 임시로 졸업로드맵을 상위 기능으로 고정합니다.

## 변경 내용
- `mju msi graduation` wrapper의 사용자-facing `viewUrl` 생성을 중단했습니다.
- `mju-news graduation-requirements list` wrapper의 사용자-facing `viewUrl` 생성을 중단했습니다.
- MSI 원본 요청까지 `academic-planning graduation-roadmap`으로 안내하도록 런타임 지침을 변경했습니다.
- 공유 `graduation` 웹뷰 chrome을 `졸업 로드맵`으로 표시하도록 바꿨습니다.
- 관련 회귀 테스트를 보강했습니다.

## 검증
- `node --test test\view-server-datatypes.test.cjs`
- `npm.cmd test`

## 배포
- 요청에 따라 PR까지만 생성합니다.
- 머지/CD는 이 PR에서 진행하지 않았습니다.
