### PR TITLE
운영 배포 전 Docker 디스크 정리 추가

### DIFF
--- a/.github/workflows/production-auto-deploy.yml
+++ b/.github/workflows/production-auto-deploy.yml
@@ -150,6 +150,17 @@ jobs:
           Set-Location $env:DEPLOY_WORKDIR
           .\deploy.ps1 -CheckOnly
 
+      - name: Free Docker disk before pull
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          docker system df
+          docker builder prune -af
+          docker image prune -af
+          docker container prune -f
+          docker system df
+
       - name: Pull production images
         shell: powershell
         run: |

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -170,6 +170,17 @@ jobs:
           Set-Location $env:DEPLOY_WORKDIR
           .\deploy.ps1 -CheckOnly
 
+      - name: Free Docker disk before pull
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          docker system df
+          docker builder prune -af
+          docker image prune -af
+          docker container prune -f
+          docker system df
+
       - name: Pull production images
         shell: powershell
         run: |


### PR DESCRIPTION
## 변경 사항
- 운영 자동 배포와 수동 배포 workflow에서 이미지 pull 직전에 Docker 디스크 사용량을 출력합니다.
- `docker builder prune -af`, `docker image prune -af`, `docker container prune -f`를 실행해 build cache, 미사용 이미지, 중지 컨테이너를 정리합니다.
- Docker volume은 정리하지 않아 운영 데이터 볼륨은 건드리지 않습니다.

## 배경
- 직전 Production Auto Deploy가 운영 Windows runner의 디스크 여유 공간 `0 MB` 상태에서 Docker layer extraction 중 30분 timeout으로 실패했습니다.
- 이번 변경은 pull 전에 공간을 확보해 같은 배포가 완료될 수 있게 하는 CD 보강입니다.

## 검증
- `npm run build && node --test test/msi-skill-override.test.cjs`
- `docker compose -f docker-compose.yml config --quiet`
- `bash -n setup.sh`
- `git diff --check`
