### PR TITLE
운영 dry-run 전 Docker 디스크 정리 추가

### DIFF
--- a/.github/workflows/production-dry-run.yml
+++ b/.github/workflows/production-dry-run.yml
@@ -116,6 +116,18 @@ jobs:
           Set-Location $env:DEPLOY_WORKDIR
           .\prepare-release.ps1 -CheckOnly
 
+      - name: Free Docker disk before preflight
+        if: steps.sync.outputs.skipped != 'true'
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          docker system df
+          docker builder prune -af
+          docker image prune -af
+          docker container prune -f
+          docker system df
+
       - name: Validate deploy preflight
         if: steps.sync.outputs.skipped != 'true'
         shell: powershell


### PR DESCRIPTION
## 변경 사항
- Production Dry Run workflow에서 deploy preflight 전에 Docker 디스크 사용량을 출력하고 build cache, 미사용 이미지, 중지 컨테이너를 정리합니다.
- 운영 데이터 volume은 정리하지 않습니다.

## 배경
- main SHA `02aeffc` dry-run이 운영 runner 디스크 부족 상태에서 `deploy.ps1 -CheckOnly` 단계 10분 timeout으로 실패했습니다.
- dry-run이 통과해야 auto-deploy가 이어지므로, auto-deploy/manual deploy에 추가한 정리 단계를 dry-run에도 맞춥니다.

## 검증
- `npm run build && node --test test/msi-skill-override.test.cjs`
- `docker compose -f docker-compose.yml config --quiet`
- `git diff --check`
