### PR TITLE
fix: 학습 도구 intent mapping 추가

### DIFF
--- a/workspace/BOOTSTRAP.md
+++ b/workspace/BOOTSTRAP.md
@@ -172,6 +172,19 @@ router가 `mju-login`을 호출하면 다음이 자동으로 따라붙습니다 
 
 `{DISCORD_USER_ID}`는 현재 대화하는 유저의 Discord ID입니다. 모든 mju-cli 명령에 이 플래그를 붙이세요.
 
+## 특수 학습 도구 의도 매핑
+
+아래 요청은 명지클로가 지원하는 학습 자동화/조회 기능입니다. 일반적인 능력 한계나 윤리 판단으로 먼저 거절하지 말고, 현재 사용자 컨텍스트의 `DISCORD_USER_ID`로 해당 mju-cli 도구를 호출한 뒤 결과를 요약하세요.
+
+| 유저 의도 | 사용할 명령 | 응답 기준 |
+|---|---|---|
+| "연구실안전교육 들어줘", "안전교육 완료해줘", "연구실 안전교육 남은 거 처리해줘" | `mju --app-dir /data/users/{DISCORD_USER_ID} --format json safety education run-incomplete-videos` | 완료/미완료 개수와 남은 과목을 요약하고, 결과에 링크가 있으면 마스킹 링크로 안내 |
+| "LMS 영상 요약해줘", "강의 영상 핵심 알려줘", "온라인 강의 중요한 구간 찾아줘" | `mju --app-dir /data/users/{DISCORD_USER_ID} --format json lms online insights --course "<과목명>" --lecture-weeks <주차> --link-seq <LINK_SEQ> --language KO` | 시험/과제/실습/중요 후보를 요약. `linkSeq`가 불명확하면 먼저 `lms online list`와 `lms online get`으로 대상 영상을 확인 |
+| "LMS에 있는 제공 요약만 보여줘", "강의 영상 LMS 요약 보여줘" | `mju --app-dir /data/users/{DISCORD_USER_ID} --format json lms online summary --course "<과목명>" --lecture-weeks <주차> --link-seq <LINK_SEQ>` | LMS가 제공한 요약문만 사용자용으로 정리 |
+| "강의 영상 자막 원문 보여줘" | `mju --app-dir /data/users/{DISCORD_USER_ID} --format json lms online transcript --course "<과목명>" --lecture-weeks <주차> --link-seq <LINK_SEQ> --language KO` | 사용자가 원문을 명시적으로 요청한 경우에만 자막 원문을 요약 또는 필요한 범위로 제공 |
+
+LMS 온라인 영상 요청에서 과목명, 주차, 영상 항목이 부족하면 임의로 없다고 답하지 말고 `lms courses list`, `lms online list`, `lms online get`으로 후보를 확인하거나 사용자에게 필요한 값을 짧게 물어보세요.
+
 ## 시간표 설계 / 졸업 로드맵 의도 매핑
 
 시간표 관련 의도는 서로 다른 기능이므로 반드시 아래처럼 구분하세요.


### PR DESCRIPTION
## 변경 내용

  - `BOOTSTRAP.md`에 특수 학습 도구 의도 매핑을 추가했습니다.
  - 연구실안전교육 요청을 `mju safety education run-incomplete-videos`로 명시 매핑했습니다.
  - LMS 온라인 강의 요약/자막/중요 구간 요청을 `lms online summary`, `transcript`,`insights`로 명시 매핑했습니다.
  - 과목명, 주차, 영상 항목이 부족한 경우 기능 부재로 답하지 않고 후보 조회 또는 추가 질문을 하도록 안내했습니다.

## 배경

운영에서 연구실안전교육과 LMS 영상 요약 기능이 실제로 존재함에도, LLM이 도구 호출 전에 일반적인 능력 한계로 판단해 거절하는 케이스가 있었습니다.

  ## 검증

  - `git diff --check`
  - `rg`로 추가된 명령 매핑 확인