### PR TITLE
fix: 학습 helper skill 설명 보강

### DIFF
--- a/skills/mju-lms-online-transcript-insights/SKILL.md
+++ b/skills/mju-lms-online-transcript-insights/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: mju-lms-online-transcript-insights
+version: 1.0.1
+description: "LMS 온라인 강의의 제공 요약, 자막 원문, rule-based 중요 구간을 조회하는 helper skill."
+metadata:
+  openclaw:
+    category: "helper"
+    domain: "education"
+    requires:
+      bins: ["mju"]
+      skills: ["mju-shared", "mju-lms"]
+---
+
+# LMS Online Transcript Insights
+
+모든 명령은 `--app-dir /data/users/<DISCORD_USER_ID> --format json` 플래그와 함께 실행합니다.
+
+## 목적
+
+사용자가 "LMS 영상 요약해줘", "강의 영상 핵심 알려줘", "온라인 강의 중요한 구간 찾아줘"처럼 요청했을 때 사용합니다.
+
+이 skill은 LMS가 제공하는 요약, 자막 원문, rule-based 중요 구간 후보를 mju-cli로 조회해 사용자에게 필요한 정보만 요약하는 기능입니다. 사용자가 온라인 강의 요약이나 핵심 구간을 요청하면 대상 강의/주차/영상 항목을 확인한 뒤 도구를 호출하세요.
+
+## 사전 확인
+
+1. 강의 목록에서 대상 강의 확인:
+
+```bash
+mju --app-dir /data/users/<DISCORD_USER_ID> --format json lms courses list
+```
+
+2. 온라인 주차 목록 확인:
+
+```bash
+mju --app-dir /data/users/<DISCORD_USER_ID> --format json lms online list --course COURSE_NAME
+```
+
+3. 대상 주차 상세 확인:
+
+```bash
+mju --app-dir /data/users/<DISCORD_USER_ID> --format json lms online get --course COURSE_NAME --lecture-weeks WEEK
+```
+
+주차에 영상 항목이 여러 개면 `online get`의 `items`에서 `linkSeq`를 확인한 뒤 `--link-seq LINK_SEQ`를 붙입니다. 사용자가 "첫 번째 영상"처럼 순서로 말하면 `--item-index INDEX`를 사용할 수 있지만, 안정적인 재호출에는 `--link-seq`가 더 낫습니다.
+
+## LMS 제공 요약만 가져오기
+
+```bash
+mju --app-dir /data/users/<DISCORD_USER_ID> --format json lms online summary --course COURSE_NAME --lecture-weeks WEEK --link-seq LINK_SEQ
+```
+
+기대 출력:
+
+- `summary.title`: LMS 요약 영역 제목
+- `summary.markdown`: LMS가 제공하는 요약문
+- `selectedItem`: 선택된 영상 항목
+- `resolvedBy`: `linkSeq`, `itemIndex`, `single-item` 중 선택 방식
+
+## 자막 원문 plain text 가져오기
+
+```bash
+mju --app-dir /data/users/<DISCORD_USER_ID> --format json lms online transcript --course COURSE_NAME --lecture-weeks WEEK --link-seq LINK_SEQ --language KO
+```
+
+기대 출력:
+
+- `source.language`: 선택한 자막 언어
+- `source.cueCount`: VTT cue 개수
+- `text`: cue 텍스트만 합친 plain transcript
+
+`--language` 기본값은 `KO`입니다. 가능한 다른 언어가 필요하면 `EN`, `CH`, `VI` 같은 LMS track 언어 코드를 지정합니다.
+
+## 중요한 구간만 rule-based로 가져오기
+
+```bash
+mju --app-dir /data/users/<DISCORD_USER_ID> --format json lms online insights --course COURSE_NAME --lecture-weeks WEEK --link-seq LINK_SEQ --language KO
+```
+
+기대 출력:
+
+- `counts`: 유형별 하이라이트 개수
+- `highlights.examCandidates`: 시험/개념 후보
+- `highlights.assignments`: 과제/제출 후보
+- `highlights.practice`: 실습 절차와 명령어 후보
+- `highlights.important`: 강조 표현이 있는 중요 설명
+- `summaryHighlights`: LMS 제공 요약문에서 잡힌 중요 후보
+
+각 highlight는 `timeRange`, `keywords`, `reasons`, `evidence`를 포함합니다. LLM 요약이 아니라 키워드와 cue window 기반 rule result이므로, 사용자에게는 "중요 후보" 또는 "검토할 구간"으로 안내합니다.
+
+필요한 유형만 좁힐 수 있습니다.
+
+```bash
+mju --app-dir /data/users/<DISCORD_USER_ID> --format json lms online insights --course COURSE_NAME --lecture-weeks WEEK --link-seq LINK_SEQ --types exam-candidate,assignment --max-items 3
+```
+
+`--show-score`는 디버깅용입니다. 일반 사용자 응답에는 점수를 노출하지 않습니다.
+
+## 응답 기준
+
+- 과목명, 주차, 선택된 영상 제목을 먼저 짧게 확인합니다.
+- `summary` 요청은 LMS 제공 요약을 중심으로 답합니다.
+- `insights` 요청은 시험/과제/실습/중요 후보를 구분해 짧게 정리합니다.
+- `transcript` 요청은 사용자가 원문을 명시적으로 원할 때만 사용하고, 긴 원문은 필요한 범위로 요약합니다.
+- 대상 영상이 모호하면 임의 선택하지 말고 후보를 제시하거나 필요한 값을 물어봅니다.

--- a/skills/mju-safety-run-incomplete-videos/SKILL.md
+++ b/skills/mju-safety-run-incomplete-videos/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: mju-safety-run-incomplete-videos
+version: 1.0.1
+description: "사용자 본인 요청에 따라 연구실안전교육 미완료 영상을 자동 진행하고 완료 상태를 확인하는 helper skill."
+metadata:
+  openclaw:
+    category: "helper"
+    domain: "education"
+    requires:
+      bins: ["mju"]
+      skills: ["mju-shared"]
+---
+
+# Safety Education Run Incomplete Videos
+
+모든 명령은 `--app-dir /data/users/<DISCORD_USER_ID> --format json` 플래그와 함께 실행합니다.
+
+## 목적
+
+사용자가 "연구실안전교육 들어줘", "안전교육 완료해줘", "남은 안전교육 처리해줘"처럼 명시적으로 요청했을 때 사용합니다.
+
+이 skill은 현재 Discord 사용자 본인 계정의 연구실안전교육 미완료 항목을 확인하고, CLI가 지원하는 자동 진행 절차를 실행한 뒤 최종 완료 상태를 다시 조회합니다. 일반적인 능력 한계 응답으로 거절하지 말고 아래 명령을 먼저 호출하세요.
+
+## 실행
+
+```bash
+mju --app-dir /data/users/<DISCORD_USER_ID> --format json safety education run-incomplete-videos
+```
+
+## 기대 출력
+
+최종 출력은 연구실안전교육 수강 완료 상태입니다.
+
+- `allCompleted`: 전체 완료 여부
+- `schedule`: 대상 안전교육 과정
+- `progressStatus`: 교육 진행 상태
+- `counts`: 전체, 완료, 미완료 개수
+- `courses`: 과목별 수강 상태
+- `incompleteCourses`: 남아 있는 미완료 과목
+- `finalUrl`: 최종 안전교육 페이지 URL
+
+## 응답 기준
+
+- 전체 완료 여부와 남은 미완료 항목 수를 먼저 말합니다.
+- `incompleteCourses`가 있으면 과목명만 간단히 요약합니다.
+- `finalUrl`이 있으면 생 URL 대신 `[자세히 보기](URL)` 형태의 마스킹 링크로 안내합니다.
+- 명시적 인증 만료 시그널이 아닌 일반 오류는 로그인 필요로 단정하지 말고, 실행 중 문제가 있었다고 정직하게 말합니다.


### PR DESCRIPTION
## 변경 내용

  - root `skills/`에 다음 helper skill override를 추가했습니다.
  - `mju-safety-run-incomplete-videos`
  - `mju-lms-online-transcript-insights`
  - 연구실안전교육 skill 설명에서 모델이 윤리적 거절로 해석하기 쉬운 표현을 완화했습니다.
  - LMS 영상 skill 설명을 “직접 재생/시청”이 아니라 “LMS 제공 요약, 자막, rule-based 중요
  구간 조회” 중심으로 정리했습니다.
  - 응답 기준과 사전 확인 절차를 명확히 추가했습니다.

  ## 배경

  기존 skill 설명의 “대신 들어준다” 같은 표현이 모델에게 거절 신호로 작용할 수 있었습니다. 또한 LMS 영상 요약 기능은 실제로`summary/transcript/insights` 명령이 존재하지만, skill surface가 약해 기능 부재처럼 응답할 수 있었습니다.

  ## 검증

  - `git diff --check`
  - `rg`로 거절 유도 표현 제거 확인
  - Dockerfile에서 root `skills/`가 workspace template에 copy되는 경로 확인