### PR TITLE
자동 배포 gate의 main push dry-run 허용

### DIFF
--- a/.github/workflows/production-auto-deploy.yml
+++ b/.github/workflows/production-auto-deploy.yml
@@ -21,7 +21,10 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.event == 'workflow_run'
+      (
+        github.event.workflow_run.event == 'workflow_run' ||
+        github.event.workflow_run.event == 'push'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -85,8 +88,9 @@ jobs:
           if ("${{ github.event.workflow_run.head_branch }}" -ne "main") {
             throw "Automatic production deploy must run from main. Current branch: ${{ github.event.workflow_run.head_branch }}"
           }
-          if ("${{ github.event.workflow_run.event }}" -ne "workflow_run") {
-            throw "Automatic production deploy must follow an automatic Production Dry Run. Current source event: ${{ github.event.workflow_run.event }}"
+          $sourceEvent = "${{ github.event.workflow_run.event }}"
+          if ($sourceEvent -notin @("workflow_run", "push")) {
+            throw "Automatic production deploy must follow an automatic Production Dry Run from main push CI. Current source event: $sourceEvent"
           }
 
       - name: Show runner context


### PR DESCRIPTION
## 변경 사항
- Production Auto Deploy gate가 Production Dry Run의 source event `push`도 허용하도록 수정했습니다.
- 수동 dry-run(`workflow_dispatch`)은 계속 자동 배포 대상에서 제외됩니다.
- guard 에러 메시지를 main push CI에서 이어진 dry-run 기준으로 정리했습니다.

## 배경
- 최신 main dry-run은 성공했지만, GitHub workflow payload에서 source event가 `push`로 들어와 auto-deploy gate가 skip됐습니다.
- main push CI → Production Dry Run 성공 → Production Auto Deploy로 이어지도록 조건을 맞춥니다.

## 검증
- `npm run build && node --test test/msi-skill-override.test.cjs`
- `bash -n setup.sh`
- `docker compose -f docker-compose.yml config --quiet`
- `git diff --check`
