### PR TITLE
운영 Docker 디스크 정리 안정화

### DIFF
--- a/.github/workflows/production-auto-deploy.yml
+++ b/.github/workflows/production-auto-deploy.yml
@@ -159,11 +159,8 @@ jobs:
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
-          docker system df
-          docker builder prune -af
-          docker image prune -af
-          docker container prune -f
-          docker system df
+          Set-Location $env:DEPLOY_WORKDIR
+          .\free-docker-disk.ps1
 
       - name: Pull production images
         shell: powershell

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -84,6 +84,14 @@ jobs:
           Set-Location $env:DEPLOY_WORKDIR
           .\prepare-release.ps1 -CheckOnly
 
+      - name: Free Docker disk before preflight
+        shell: powershell
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          Set-Location $env:DEPLOY_WORKDIR
+          .\free-docker-disk.ps1
+
       - name: Validate deploy preflight
         shell: powershell
         run: |
@@ -175,11 +183,8 @@ jobs:
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
-          docker system df
-          docker builder prune -af
-          docker image prune -af
-          docker container prune -f
-          docker system df
+          Set-Location $env:DEPLOY_WORKDIR
+          .\free-docker-disk.ps1
 
       - name: Pull production images
         shell: powershell

--- a/.github/workflows/production-dry-run.yml
+++ b/.github/workflows/production-dry-run.yml
@@ -122,11 +122,8 @@ jobs:
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
-          docker system df
-          docker builder prune -af
-          docker image prune -af
-          docker container prune -f
-          docker system df
+          Set-Location $env:DEPLOY_WORKDIR
+          .\free-docker-disk.ps1
 
       - name: Validate deploy preflight
         if: steps.sync.outputs.skipped != 'true'

--- a/free-docker-disk.ps1
+++ b/free-docker-disk.ps1
@@ -1,0 +1,83 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Show-DiskUsage {
+  Write-Host "Filesystem usage:"
+  Get-PSDrive -PSProvider FileSystem |
+    Select-Object Name, Used, Free, Root |
+    Format-Table -AutoSize |
+    Out-String |
+    Write-Host
+}
+
+function Clear-DirectoryContents {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+    return
+  }
+
+  Write-Host "Clearing directory contents: $Path"
+  Get-ChildItem -LiteralPath $Path -Force -ErrorAction SilentlyContinue |
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+function Invoke-NativeWithTimeout {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$FilePath,
+
+    [Parameter(Mandatory = $true)]
+    [string[]]$Arguments,
+
+    [int]$TimeoutSeconds = 120
+  )
+
+  Write-Host "> $FilePath $($Arguments -join ' ')"
+
+  $process = New-Object System.Diagnostics.Process
+  $process.StartInfo.FileName = $FilePath
+  $process.StartInfo.Arguments = ($Arguments | ForEach-Object {
+    if ($_ -match '[\s"]') {
+      '"' + ($_ -replace '"', '\"') + '"'
+    }
+    else {
+      $_
+    }
+  }) -join " "
+  $process.StartInfo.UseShellExecute = $false
+
+  [void]$process.Start()
+
+  if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+    try {
+      $process.Kill()
+    }
+    catch {
+      Write-Warning "Failed to kill timed out process: $_"
+    }
+    throw "$FilePath $($Arguments -join ' ') did not finish within $TimeoutSeconds seconds. The Docker daemon may be unresponsive or the host disk may be full."
+  }
+
+  if ($process.ExitCode -ne 0) {
+    throw "$FilePath $($Arguments -join ' ') failed with exit code $($process.ExitCode)."
+  }
+}
+
+Show-DiskUsage
+
+if ($env:RUNNER_TEMP) {
+  Clear-DirectoryContents -Path $env:RUNNER_TEMP
+}
+
+Show-DiskUsage
+
+Invoke-NativeWithTimeout -FilePath "docker" -Arguments @("builder", "prune", "-af") -TimeoutSeconds 120
+Invoke-NativeWithTimeout -FilePath "docker" -Arguments @("image", "prune", "-af") -TimeoutSeconds 120
+Invoke-NativeWithTimeout -FilePath "docker" -Arguments @("container", "prune", "-f") -TimeoutSeconds 120
+Invoke-NativeWithTimeout -FilePath "docker" -Arguments @("system", "df") -TimeoutSeconds 120
+
+Show-DiskUsage


### PR DESCRIPTION
## 변경 사항
- 운영 dry-run/auto/manual deploy에서 공통 `free-docker-disk.ps1` 정리 스크립트를 사용하도록 정리했습니다.
- Docker 정리 전 러너 파일시스템 사용량과 `RUNNER_TEMP` 정리를 먼저 수행합니다.
- Docker 명령이 멈출 경우 120초 타임아웃으로 명확히 실패하게 해 운영 러너 디스크/데몬 문제를 빠르게 구분할 수 있게 했습니다.

## 검증
- `npm run build`
- `node --test test/msi-skill-override.test.cjs`
- `docker compose -f docker-compose.yml config --quiet`
- `git diff --check`