### PR TITLE
운영 Docker 엔진 자동 복구 추가

### DIFF
--- a/free-docker-disk.ps1
+++ b/free-docker-disk.ps1
@@ -67,6 +67,60 @@ function Invoke-NativeWithTimeout {
   }
 }
 
+function Test-DockerEngine {
+  try {
+    Invoke-NativeWithTimeout -FilePath "docker" -Arguments @("info") -TimeoutSeconds 30
+    return $true
+  }
+  catch {
+    Write-Warning "Docker engine is not responding: $_"
+    return $false
+  }
+}
+
+function Start-DockerDesktop {
+  $dockerDesktopPath = Join-Path $env:ProgramFiles "Docker\Docker\Docker Desktop.exe"
+  if (Test-Path -LiteralPath $dockerDesktopPath -PathType Leaf) {
+    Write-Host "Starting Docker Desktop: $dockerDesktopPath"
+    Start-Process -FilePath $dockerDesktopPath | Out-Null
+  }
+  else {
+    Write-Warning "Docker Desktop executable not found: $dockerDesktopPath"
+  }
+}
+
+function Restart-DockerEngine {
+  Write-Host "Restarting Docker engine before production Docker commands."
+
+  $service = Get-Service -Name "com.docker.service" -ErrorAction SilentlyContinue
+  if ($service) {
+    Restart-Service -Name "com.docker.service" -Force -ErrorAction Stop
+  }
+  else {
+    Write-Warning "Docker service com.docker.service was not found."
+  }
+
+  Start-DockerDesktop
+}
+
+function Wait-DockerEngine {
+  param(
+    [int]$TimeoutSeconds = 180
+  )
+
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  while ((Get-Date) -lt $deadline) {
+    if (Test-DockerEngine) {
+      Write-Host "Docker engine is responding."
+      return
+    }
+
+    Start-Sleep -Seconds 10
+  }
+
+  throw "Docker engine did not become ready within $TimeoutSeconds seconds."
+}
+
 Show-DiskUsage
 
 if ($env:RUNNER_TEMP) {
@@ -74,6 +128,11 @@ if ($env:RUNNER_TEMP) {
 }
 
 Show-DiskUsage
+
+if (-not (Test-DockerEngine)) {
+  Restart-DockerEngine
+  Wait-DockerEngine -TimeoutSeconds 180
+}
 
 Invoke-NativeWithTimeout -FilePath "docker" -Arguments @("builder", "prune", "-af") -TimeoutSeconds 120
 Invoke-NativeWithTimeout -FilePath "docker" -Arguments @("image", "prune", "-af") -TimeoutSeconds 120


### PR DESCRIPTION
## 변경 사항
- 운영 Docker 정리 전에 `docker info`로 Docker engine 응답 상태를 확인합니다.
- Docker Desktop Linux engine이 응답하지 않으면 `com.docker.service` 재시작과 Docker Desktop 기동을 시도합니다.
- Docker engine이 준비될 때까지 최대 180초 대기한 뒤 기존 prune/pull 전 정리 루틴을 이어갑니다.

## 배경
- 운영 dry-run에서 디스크 여유는 42GB로 회복됐지만 `dockerDesktopLinuxEngine/_ping: context deadline exceeded`로 Docker engine이 응답하지 않았습니다.

## 검증
- `npm run build`
- `node --test test/msi-skill-override.test.cjs`
- `docker compose -f docker-compose.yml config --quiet`
- `git diff --check`