### PR TITLE
운영 Docker Desktop 경로 탐색 보강

### DIFF
--- a/free-docker-disk.ps1
+++ b/free-docker-disk.ps1
@@ -79,20 +79,53 @@ function Test-DockerEngine {
 }
 
 function Start-DockerDesktop {
-  $dockerDesktopPath = Join-Path $env:ProgramFiles "Docker\Docker\Docker Desktop.exe"
-  if (Test-Path -LiteralPath $dockerDesktopPath -PathType Leaf) {
-    Write-Host "Starting Docker Desktop: $dockerDesktopPath"
-    Start-Process -FilePath $dockerDesktopPath | Out-Null
+  $candidates = New-Object System.Collections.Generic.List[string]
+
+  if ($env:ProgramFiles) {
+    $candidates.Add((Join-Path $env:ProgramFiles "Docker\Docker\Docker Desktop.exe"))
   }
-  else {
-    Write-Warning "Docker Desktop executable not found: $dockerDesktopPath"
+  if (${env:ProgramFiles(x86)}) {
+    $candidates.Add((Join-Path ${env:ProgramFiles(x86)} "Docker\Docker\Docker Desktop.exe"))
   }
+  if ($env:LOCALAPPDATA) {
+    $candidates.Add((Join-Path $env:LOCALAPPDATA "Docker\Docker Desktop.exe"))
+    $candidates.Add((Join-Path $env:LOCALAPPDATA "Programs\Docker\Docker\Docker Desktop.exe"))
+  }
+
+  $dockerCommand = Get-Command docker -ErrorAction SilentlyContinue
+  if ($dockerCommand) {
+    Write-Host "Docker CLI path: $($dockerCommand.Source)"
+    $directory = Get-Item -LiteralPath (Split-Path -Parent $dockerCommand.Source)
+    while ($directory) {
+      $candidates.Add((Join-Path $directory.FullName "Docker Desktop.exe"))
+      $directory = $directory.Parent
+    }
+  }
+
+  $dockerDesktopPath = $candidates |
+    Where-Object { $_ -and (Test-Path -LiteralPath $_ -PathType Leaf) } |
+    Select-Object -First 1
+
+  if (-not $dockerDesktopPath) {
+    Write-Warning "Docker Desktop executable was not found in known locations."
+    return
+  }
+
+  Write-Host "Starting Docker Desktop: $dockerDesktopPath"
+  Start-Process -FilePath $dockerDesktopPath | Out-Null
 }
 
 function Restart-DockerEngine {
   Write-Host "Restarting Docker engine before production Docker commands."
 
-  $service = Get-Service -Name "com.docker.service" -ErrorAction SilentlyContinue
+  $dockerServices = Get-Service -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -like "*docker*" -or $_.DisplayName -like "*docker*" }
+  if ($dockerServices) {
+    Write-Host "Docker-related services:"
+    $dockerServices | Format-Table -AutoSize | Out-String | Write-Host
+  }
+
+  $service = $dockerServices | Where-Object { $_.Name -eq "com.docker.service" } | Select-Object -First 1
   if ($service) {
     Restart-Service -Name "com.docker.service" -Force -ErrorAction Stop
   }


### PR DESCRIPTION
## 변경 사항
- Docker engine 복구 시 Docker Desktop 실행 파일을 표준 Program Files 경로뿐 아니라 AppData 설치 경로와 `docker.exe` 상위 디렉터리에서도 탐색합니다.
- 운영 러너에 등록된 Docker 관련 Windows 서비스를 로그로 출력해 다음 장애 진단 근거를 남깁니다.

## 배경
- 운영 dry-run에서 디스크 여유는 42GB였지만 Docker engine이 응답하지 않았습니다.
- 러너에는 Docker CLI가 있으나 `com.docker.service`와 표준 Docker Desktop 경로가 없어 자동 복구가 Docker Desktop을 찾지 못했습니다.

## 검증
- `npm run build`
- `node --test test/msi-skill-override.test.cjs`
- `git diff --check`