### PR TITLE
운영 dry-run workflow 조건 들여쓰기 수정

### DIFF
--- a/.github/workflows/production-dry-run.yml
+++ b/.github/workflows/production-dry-run.yml
@@ -25,7 +25,7 @@ jobs:
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.head_branch == 'main' &&
         github.event.workflow_run.event == 'push'
-    )
+      )
     runs-on: [self-hosted, Windows, mjuclaw-prod-windows]
     timeout-minutes: 15
 


### PR DESCRIPTION
## 변경 사항
- `production-dry-run.yml`의 job-level `if` 블록 닫는 괄호 들여쓰기를 수정했습니다.

## 배경
- PR #86 머지 직후 GitHub가 workflow 파일 자체를 invalid로 처리해 job 없이 실패 run을 만들었습니다.

## 검증
- `npm run build`
- `node --test test/msi-skill-override.test.cjs`
- `git diff --check`