### PR TITLE
학사 계획 라우팅 보강 배포 롤백

### DIFF
--- a/bin/mju
+++ b/bin/mju
@@ -179,25 +179,21 @@ PY
 )
 
 if [[ -n "$VIEW_URL" ]]; then
-  PYTHONIOENCODING=utf-8 RAW_STDOUT_FILE="$STDOUT_FILE" VIEW_URL="$VIEW_URL" DATA_TYPE="$DATA_TYPE" TITLE="$TITLE" "$PYTHON_BIN" - <<'PY'
+  PYTHONIOENCODING=utf-8 RAW_STDOUT_FILE="$STDOUT_FILE" VIEW_URL="$VIEW_URL" "$PYTHON_BIN" - <<'PY'
 import json
 import os
 
 with open(os.environ["RAW_STDOUT_FILE"], encoding="utf-8") as handle:
     raw = handle.read()
 view_url = os.environ["VIEW_URL"]
-view_data_type = os.environ["DATA_TYPE"]
-view_title = os.environ["TITLE"]
 
 try:
     data = json.loads(raw)
     if isinstance(data, dict):
         data["viewUrl"] = view_url
-        data["viewDataType"] = view_data_type
-        data["viewTitle"] = view_title
         print(json.dumps(data, ensure_ascii=False))
     else:
-        print(json.dumps({"data": data, "viewUrl": view_url, "viewDataType": view_data_type, "viewTitle": view_title}, ensure_ascii=False))
+        print(json.dumps({"data": data, "viewUrl": view_url}, ensure_ascii=False))
 except Exception:
     print(raw)
 PY

--- a/bin/mju-academic-planning
+++ b/bin/mju-academic-planning
@@ -80,17 +80,16 @@ need_bin python3
 
 default_term() {
   python3 - <<'PY'
-import os
 from datetime import datetime
-
-override = os.environ.get("MJU_ACADEMIC_PLANNING_NOW", "").strip()
-now = datetime.fromisoformat(override.replace("Z", "+00:00")) if override else datetime.now()
+now = datetime.now()
 year = now.year
 month = now.month
-if month <= 8:
+if month <= 2:
     print(f"{year} 10")
-else:
+elif month <= 8:
     print(f"{year} 20")
+else:
+    print(f"{year + 1} 10")
 PY
 }
 
@@ -105,106 +104,6 @@ if [[ "${MJU_ACADEMIC_PLANNING_KEEP_TMP:-}" != "1" ]]; then
   trap 'rm -rf "$TMP_DIR"' EXIT
 fi
 
-diag_timestamp() {
-  date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || python3 - <<'PY'
-from datetime import datetime, timezone
-print(datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"))
-PY
-}
-
-emit_diag() {
-  local status="$1"
-  local stage="$2"
-  local exit_code="$3"
-  local message="$4"
-  local command_display="$5"
-  local stdout_file="${6:-}"
-  local stderr_file="${7:-}"
-
-  PYTHONIOENCODING=utf-8 \
-  DIAG_STATUS="$status" \
-  DIAG_STAGE="$stage" \
-  DIAG_EXIT_CODE="$exit_code" \
-  DIAG_MESSAGE="$message" \
-  DIAG_COMMAND="$command_display" \
-  DIAG_STDOUT_FILE="$stdout_file" \
-  DIAG_STDERR_FILE="$stderr_file" \
-  DIAG_MODE="$MODE" \
-  DIAG_DISCORD_ID="$DISCORD_ID" \
-  DIAG_WHEN="$(diag_timestamp)" \
-  python3 - <<'PY' >&2
-import json
-import os
-import re
-from pathlib import Path
-
-def scrub(value: str) -> str:
-    discord_id = os.environ.get("DIAG_DISCORD_ID", "")
-    if discord_id:
-        value = value.replace(discord_id, "<discord_id>")
-    value = re.sub(r"\b\d{9,20}\b", "<number>", value)
-    return value[-2000:]
-
-def tail(path: str) -> str:
-    if not path:
-        return ""
-    try:
-        return scrub(Path(path).read_text(encoding="utf-8", errors="replace"))
-    except Exception:
-        return ""
-
-payload = {
-    "feature": "academic-planning",
-    "mode": os.environ["DIAG_MODE"],
-    "status": os.environ["DIAG_STATUS"],
-    "stage": os.environ["DIAG_STAGE"],
-    "when": os.environ["DIAG_WHEN"],
-    "exitCode": int(os.environ["DIAG_EXIT_CODE"]),
-    "message": scrub(os.environ["DIAG_MESSAGE"]),
-    "command": scrub(os.environ["DIAG_COMMAND"]),
-}
-stderr_tail = tail(os.environ.get("DIAG_STDERR_FILE", ""))
-stdout_tail = tail(os.environ.get("DIAG_STDOUT_FILE", ""))
-if stderr_tail:
-    payload["stderrTail"] = stderr_tail
-if stdout_tail:
-    payload["stdoutTail"] = stdout_tail
-print("MJU_ACADEMIC_PLANNING_DIAG " + json.dumps(payload, ensure_ascii=False))
-PY
-}
-
-run_context_stage() {
-  local stage="$1"
-  local output_file="$2"
-  local required="$3"
-  shift 3
-
-  local safe_stage="${stage//[^A-Za-z0-9_.-]/_}"
-  local stderr_file="$TMP_DIR/${safe_stage}.stderr"
-  local command_display="MJU_SKIP_VIEW=$SKIP_VIEW_ENV $*"
-
-  set +e
-  MJU_SKIP_VIEW="$SKIP_VIEW_ENV" "$@" > "$output_file" 2>"$stderr_file"
-  local exit_code=$?
-  set -e
-
-  if [[ $exit_code -ne 0 ]]; then
-    local status="warning"
-    local message="optional context command failed; continuing with fallback"
-    if [[ "$required" == "1" ]]; then
-      status="failed"
-      message="required context command failed"
-    fi
-    emit_diag "$status" "$stage" "$exit_code" "$message" "$command_display" "$output_file" "$stderr_file"
-    if [[ "$required" == "1" ]]; then
-      exit "$exit_code"
-    fi
-    printf '{}\n' > "$output_file"
-  elif [[ "${MJU_ACADEMIC_PLANNING_DEBUG:-}" == "1" ]]; then
-    emit_diag "succeeded" "$stage" "0" "context command succeeded" "$command_display" "$output_file" "$stderr_file"
-  fi
-}
-
 APP_DIR="/data/users/$DISCORD_ID"
 PROFILE_JSON="$TMP_DIR/profile.json"
 GRADE_HISTORY_JSON="$TMP_DIR/grade-history.json"
@@ -217,16 +116,27 @@ INFO_JSON="$TMP_DIR/info.json"
 # final mju-news call below still uses the normal VIEW_API_URL.
 SKIP_VIEW_ENV="${MJU_ACADEMIC_PLANNING_SKIP_VIEW:-1}"
 
-run_context_stage "profile.get" "$PROFILE_JSON" "0" mju --app-dir "$APP_DIR" --format json profile get
-run_context_stage "msi.grade-history" "$GRADE_HISTORY_JSON" "1" mju --app-dir "$APP_DIR" --format json msi grade-history
-run_context_stage "msi.timetable.current" "$CURRENT_TIMETABLE_JSON" "0" mju --app-dir "$APP_DIR" --format json msi timetable
+if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju --app-dir "$APP_DIR" --format json profile get > "$PROFILE_JSON"; then
+  printf '{}\n' > "$PROFILE_JSON"
+fi
+
+if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju --app-dir "$APP_DIR" --format json msi grade-history > "$GRADE_HISTORY_JSON"; then
+  echo "ERR: failed to read MSI grade history for academic planning" >&2
+  cat "$GRADE_HISTORY_JSON" >&2 2>/dev/null || true
+  exit 1
+fi
+
+if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju --app-dir "$APP_DIR" --format json msi timetable > "$CURRENT_TIMETABLE_JSON"; then
+  printf '{}\n' > "$CURRENT_TIMETABLE_JSON"
+fi
 
 DEPARTMENT_ARGS=("--app-dir" "$APP_DIR" "--format" "json" "msi" "department-timetable")
 if [[ -n "$YEAR" ]]; then DEPARTMENT_ARGS+=("--year" "$YEAR"); fi
 if [[ -n "$TERM_CODE" ]]; then DEPARTMENT_ARGS+=("--term-code" "$TERM_CODE"); fi
-run_context_stage "msi.department-timetable.requested" "$DEPARTMENT_TIMETABLE_JSON" "0" mju "${DEPARTMENT_ARGS[@]}"
-if [[ "$(tr -d '[:space:]' < "$DEPARTMENT_TIMETABLE_JSON" 2>/dev/null || true)" == "{}" ]]; then
-  run_context_stage "msi.department-timetable.default" "$DEPARTMENT_TIMETABLE_JSON" "0" mju --app-dir "$APP_DIR" --format json msi department-timetable
+if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju "${DEPARTMENT_ARGS[@]}" > "$DEPARTMENT_TIMETABLE_JSON"; then
+  if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju --app-dir "$APP_DIR" --format json msi department-timetable > "$DEPARTMENT_TIMETABLE_JSON"; then
+    printf '{}\n' > "$DEPARTMENT_TIMETABLE_JSON"
+  fi
 fi
 
 EXPLICIT_DEPARTMENT="$DEPARTMENT" \
@@ -394,53 +304,4 @@ fi
 MJU_NEWS_ARGS+=("--personal-msi-json" "$PERSONAL_JSON")
 MJU_NEWS_ARGS+=("--completed-courses-json" "$GRADE_HISTORY_JSON")
 
-EXPECTED_VIEW_DATA_TYPE="graduation"
-if [[ "$MODE" == "timetable" ]]; then
-  EXPECTED_VIEW_DATA_TYPE="timetable-planner"
-fi
-
-MJU_NEWS_STDOUT="$TMP_DIR/mju-news-output.json"
-MJU_NEWS_STDERR="$TMP_DIR/mju-news.stderr"
-set +e
-mju-news "${MJU_NEWS_ARGS[@]}" > "$MJU_NEWS_STDOUT" 2>"$MJU_NEWS_STDERR"
-MJU_NEWS_EXIT=$?
-set -e
-
-if [[ $MJU_NEWS_EXIT -ne 0 ]]; then
-  emit_diag "failed" "mju-news.academic-planning" "$MJU_NEWS_EXIT" "academic planning reader command failed" "mju-news ${MJU_NEWS_ARGS[*]}" "$MJU_NEWS_STDOUT" "$MJU_NEWS_STDERR"
-  cat "$MJU_NEWS_STDOUT"
-  exit "$MJU_NEWS_EXIT"
-fi
-
-VALIDATE_STDERR="$TMP_DIR/view-validate.stderr"
-if ! EXPECTED_VIEW_DATA_TYPE="$EXPECTED_VIEW_DATA_TYPE" OUTPUT_FILE="$MJU_NEWS_STDOUT" python3 - <<'PY' 2>"$VALIDATE_STDERR"
-import json
-import os
-import sys
-from pathlib import Path
-
-expected = os.environ["EXPECTED_VIEW_DATA_TYPE"]
-try:
-    data = json.loads(Path(os.environ["OUTPUT_FILE"]).read_text(encoding="utf-8"))
-except Exception as exc:
-    print(f"invalid helper output JSON: {exc}", file=sys.stderr)
-    sys.exit(20)
-
-if not isinstance(data, dict):
-    print("helper output is not a JSON object", file=sys.stderr)
-    sys.exit(21)
-if not data.get("viewUrl"):
-    print("helper output is missing viewUrl", file=sys.stderr)
-    sys.exit(22)
-actual = data.get("viewDataType")
-if actual != expected:
-    print(f"helper output viewDataType mismatch: expected={expected} actual={actual!r}", file=sys.stderr)
-    sys.exit(23)
-PY
-then
-  emit_diag "failed" "view.validate" "1" "academic planning webview output did not match expected type" "mju-news ${MJU_NEWS_ARGS[*]}" "$MJU_NEWS_STDOUT" "$VALIDATE_STDERR"
-  cat "$MJU_NEWS_STDOUT"
-  exit 1
-fi
-
-cat "$MJU_NEWS_STDOUT"
+mju-news "${MJU_NEWS_ARGS[@]}"

--- a/bin/mju-news
+++ b/bin/mju-news
@@ -160,25 +160,21 @@ PY
 )
 
 if [[ -n "$VIEW_URL" ]]; then
-  PYTHONIOENCODING=utf-8 RAW_STDOUT_FILE="$STDOUT_FILE" VIEW_URL="$VIEW_URL" DATA_TYPE="$DATA_TYPE" TITLE="$TITLE" "$PYTHON_BIN" - <<'PY'
+  PYTHONIOENCODING=utf-8 RAW_STDOUT_FILE="$STDOUT_FILE" VIEW_URL="$VIEW_URL" "$PYTHON_BIN" - <<'PY'
 import json
 import os
 
 with open(os.environ["RAW_STDOUT_FILE"], encoding="utf-8") as handle:
     raw = handle.read()
 view_url = os.environ["VIEW_URL"]
-view_data_type = os.environ["DATA_TYPE"]
-view_title = os.environ["TITLE"]
 
 try:
     data = json.loads(raw)
     if isinstance(data, dict):
         data["viewUrl"] = view_url
-        data["viewDataType"] = view_data_type
-        data["viewTitle"] = view_title
         print(json.dumps(data, ensure_ascii=False))
     else:
-        print(json.dumps({"data": data, "viewUrl": view_url, "viewDataType": view_data_type, "viewTitle": view_title}, ensure_ascii=False))
+        print(json.dumps({"data": data, "viewUrl": view_url}, ensure_ascii=False))
 except Exception:
     print(raw)
 PY

--- a/test/academic-planning-helper.test.cjs
+++ b/test/academic-planning-helper.test.cjs
@@ -57,7 +57,7 @@ function run(command, args, options) {
   });
 }
 
-async function createFixture(t, options = {}) {
+async function createFixture(t) {
   const testDir = path.join(root, ".tmp", `academic-planning-helper-${process.pid}-${Math.random().toString(16).slice(2)}`);
   await fs.rm(testDir, { recursive: true, force: true });
   await fs.mkdir(testDir, { recursive: true });
@@ -67,8 +67,6 @@ async function createFixture(t, options = {}) {
   await fs.mkdir(stubBin, { recursive: true });
   const mjuCalls = path.join(testDir, "mju-calls.txt");
   const mjuNewsArgs = path.join(testDir, "mju-news-args.txt");
-  const gradeHistoryFails = Boolean(options.gradeHistoryFails);
-  const mjuNewsViewDataType = options.mjuNewsViewDataType ?? "";
 
   const python3Stub = path.join(stubBin, "python3");
   await fs.writeFile(python3Stub, `#!/usr/bin/env bash
@@ -93,10 +91,6 @@ case "$joined" in
 JSON
     ;;
   *" msi grade-history"*)
-    if [[ "${gradeHistoryFails ? "1" : "0"}" == "1" ]]; then
-      echo "grade history boom for 123456789012345678" >&2
-      exit 42
-    fi
     cat <<'JSON'
 {"studentInfo":{"학과":"컴퓨터공학과","학번":"202112345"},"termRecords":[{"year":2021,"termLabel":"1학기","courses":[{"courseTitle":"미적분학1","courseCode":"KME02101","credit":3,"categoryLabel":"학문기초교양"}]}]}
 JSON
@@ -123,29 +117,18 @@ esac
   await fs.writeFile(mjuNewsStub, `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\\n' "$@" > "${toBashPath(mjuNewsArgs)}"
-mode="\${2:-unknown}"
-case "$mode" in
-  timetable) dtype="timetable-planner" ;;
-  graduation-roadmap) dtype="graduation" ;;
-  *) dtype="unknown" ;;
-esac
-if [[ -n "${mjuNewsViewDataType}" ]]; then
-  dtype="${mjuNewsViewDataType}"
-fi
-printf '{"viewUrl":"http://view.local/%s","viewDataType":"%s","ok":true}\\n' "$mode" "$dtype"
+printf '{"viewUrl":"http://view.local/%s","ok":true}\\n' "\${2:-unknown}"
 `, "utf8");
   await fs.chmod(mjuNewsStub, 0o755);
 
   return { stubBin, mjuCalls, mjuNewsArgs };
 }
 
-async function runHelper(fixture, args, env = {}) {
+async function runHelper(fixture, args) {
   const helper = toBashPath(path.join(root, "bin", "mju-academic-planning"));
-  const envAssignments = Object.entries(env).map(([key, value]) => `${key}=${shellQuote(value)}`);
   const command = [
     `PATH=${shellQuote(toBashPath(fixture.stubBin))}:$PATH`,
     "MJU_ACADEMIC_PLANNING_KEEP_TMP=1",
-    ...envAssignments,
     shellQuote(helper),
     ...args.map(shellQuote),
   ].join(" ");
@@ -162,14 +145,6 @@ function valueAfter(args, flag) {
   return args[index + 1];
 }
 
-function diagnosticEvents(stderr) {
-  const prefix = "MJU_ACADEMIC_PLANNING_DIAG ";
-  return stderr
-    .split(/\r?\n/)
-    .filter((line) => line.startsWith(prefix))
-    .map((line) => JSON.parse(line.slice(prefix.length)));
-}
-
 bashTest("academic planning helper enriches graduation roadmap calls with MSI context", async (t) => {
   const fixture = await createFixture(t);
   const result = await runHelper(fixture, [
@@ -181,7 +156,6 @@ bashTest("academic planning helper enriches graduation roadmap calls with MSI co
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /"viewUrl":"http:\/\/view\.local\/graduation-roadmap"/);
-  assert.match(result.stdout, /"viewDataType":"graduation"/);
 
   const args = await readArgs(fixture.mjuNewsArgs);
   assert.deepEqual(args.slice(0, 2), ["academic-planning", "graduation-roadmap"]);
@@ -214,7 +188,6 @@ bashTest("academic planning helper routes timetable generation without UCheck", 
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /"viewUrl":"http:\/\/view\.local\/timetable"/);
-  assert.match(result.stdout, /"viewDataType":"timetable-planner"/);
 
   const args = await readArgs(fixture.mjuNewsArgs);
   assert.deepEqual(args.slice(0, 2), ["academic-planning", "timetable"]);
@@ -229,64 +202,4 @@ bashTest("academic planning helper routes timetable generation without UCheck", 
   assert.match(mjuCalls, /msi grade-history/);
   assert.match(mjuCalls, /msi department-timetable/);
   assert.doesNotMatch(mjuCalls, /ucheck/);
-});
-
-bashTest("academic planning helper defaults timetable planning to the published first semester in May", async (t) => {
-  const fixture = await createFixture(t);
-  const result = await runHelper(fixture, [
-    "timetable",
-    "123456789012345678",
-    "--format",
-    "json",
-  ], { MJU_ACADEMIC_PLANNING_NOW: "2026-05-30T12:00:00" });
-
-  assert.equal(result.status, 0, result.stderr);
-
-  const args = await readArgs(fixture.mjuNewsArgs);
-  assert.deepEqual(args.slice(0, 2), ["academic-planning", "timetable"]);
-  assert.equal(valueAfter(args, "--year"), "2026");
-  assert.equal(valueAfter(args, "--term-code"), "10");
-});
-
-bashTest("academic planning helper emits structured diagnostics when required MSI context fails", async (t) => {
-  const fixture = await createFixture(t, { gradeHistoryFails: true });
-  const result = await runHelper(fixture, [
-    "graduation-roadmap",
-    "123456789012345678",
-    "--format",
-    "json",
-  ]);
-
-  assert.equal(result.status, 42);
-  assert.doesNotMatch(result.stderr, /123456789012345678/);
-  const events = diagnosticEvents(result.stderr);
-  const failure = events.find((event) => event.stage === "msi.grade-history");
-  assert.ok(failure, result.stderr);
-  assert.equal(failure.feature, "academic-planning");
-  assert.equal(failure.mode, "graduation-roadmap");
-  assert.equal(failure.status, "failed");
-  assert.equal(failure.exitCode, 42);
-  assert.match(failure.stderrTail, /grade history boom/);
-});
-
-bashTest("academic planning helper rejects mismatched webview data types", async (t) => {
-  const fixture = await createFixture(t, { mjuNewsViewDataType: "attendance" });
-  const result = await runHelper(fixture, [
-    "timetable",
-    "123456789012345678",
-    "--year",
-    "2026",
-    "--term-code",
-    "20",
-    "--format",
-    "json",
-  ]);
-
-  assert.equal(result.status, 1);
-  assert.match(result.stdout, /"viewDataType":"attendance"/);
-  const events = diagnosticEvents(result.stderr);
-  const failure = events.find((event) => event.stage === "view.validate");
-  assert.ok(failure, result.stderr);
-  assert.equal(failure.status, "failed");
-  assert.match(failure.stderrTail, /expected=timetable-planner/);
 });

--- a/test/mju-news-wrapper-academic-planning.test.cjs
+++ b/test/mju-news-wrapper-academic-planning.test.cjs
@@ -145,7 +145,6 @@ bashTest("mju-news wrapper routes course catalog reads to the timetable planner 
 
   const output = JSON.parse(result.stdout);
   assert.equal(output.viewUrl, "http://view.local/timetable-planner");
-  assert.equal(output.viewDataType, "timetable-planner");
 });
 
 bashTest("mju-news wrapper leaves standalone graduation requirements unviewed", async (t) => {
@@ -213,7 +212,6 @@ bashTest("mju-news wrapper routes academic-planning timetable to the timetable p
 
   const output = JSON.parse(result.stdout);
   assert.equal(output.viewUrl, "http://view.local/academic-timetable");
-  assert.equal(output.viewDataType, "timetable-planner");
 });
 
 bashTest("mju-news wrapper posts large academic-planning payload through a body file", async (t) => {
@@ -288,7 +286,6 @@ bashTest("mju-news wrapper routes academic-planning graduation-roadmap to the gr
 
   const output = JSON.parse(result.stdout);
   assert.equal(output.viewUrl, "http://view.local/academic-graduation");
-  assert.equal(output.viewDataType, "graduation");
 });
 
 async function fileExists(filePath) {

--- a/test/mju-wrapper-course-scores.test.cjs
+++ b/test/mju-wrapper-course-scores.test.cjs
@@ -138,33 +138,7 @@ bashTest("mju wrapper routes course-scores to the view API and injects viewUrl",
 
   const output = JSON.parse(result.stdout);
   assert.equal(output.viewUrl, "http://view.local/course-scores-test");
-  assert.equal(output.viewDataType, "course-scores");
   assert.equal(output.courses[0].title, "0752 - 시스템클라우드보안");
-});
-
-bashTest("mju wrapper routes current MSI timetable to timetable webview metadata", async (t) => {
-  const fixture = await createWrapperFixture(t, {
-    entries: [{ courseTitle: "Capstone Design", classroom: "Y5441" }],
-  });
-
-  const result = await run("bash", ["-lc", wrapperCommand(fixture, [
-    "msi",
-    "timetable",
-    "--app-dir",
-    toBashPath(path.join(fixture.testDir, "app")),
-    "--format",
-    "json",
-  ])], { cwd: fixture.root });
-
-  assert.equal(result.status, 0, result.stderr);
-
-  const requestBody = JSON.parse(await fs.readFile(fixture.curlCapture, "utf8"));
-  assert.equal(requestBody.dataType, "timetable");
-  assert.notEqual(requestBody.dataType, "attendance");
-
-  const output = JSON.parse(result.stdout);
-  assert.equal(output.viewDataType, "timetable");
-  assert.equal(output.entries[0].courseTitle, "Capstone Design");
 });
 
 for (const legacyCommand of ["current-grades", "grades", "graduation"]) {


### PR DESCRIPTION
## 목적

운영에서 #89 배포 이후 시간표 설계/졸업 로드맵 요청 매핑과 웹뷰 연결이 개선되지 않고 일부 기존 매핑까지 악화되어, 직전 성공 배포 상태로 우선 복구합니다.

## 변경

- #89 merge commit 959a3f의 변경을 revert합니다.
- in/mju-academic-planning, in/mju, in/mju-news의 후단 타입 검증/메타데이터 보강을 직전 상태로 되돌립니다.
- 관련 테스트 추가분도 함께 되돌립니다.

## 검증

- 
pm.cmd test
- 결과: 120 tests, 107 passed, 13 skipped, 0 failed

## 배포

이 PR 머지 후 mjuclaw-setup main 기준 CI → Production Dry Run → Production Auto Deploy가 다시 실행되어 직전 동작으로 복구되는지 확인합니다.