### PR TITLE
운영 라우터에 학사 계획 DB 경로 연결

### DIFF
--- a/bin/mju-academic-planning
+++ b/bin/mju-academic-planning
@@ -87,7 +87,7 @@ month = now.month
 if month <= 2:
     print(f"{year} 10")
 elif month <= 8:
-    print(f"{year} 20")
+    print(f"{year} 10")
 else:
     print(f"{year + 1} 10")
 PY

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,6 +52,7 @@ services:
       - USER_DATA_ROOT=/data/users
       - OPENCLAW_GATEWAY_URL=${OPENCLAW_GATEWAY_URL:-ws://mjuclaw-agent:18789}
       - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
+      - VIEW_SERVER_URL=${VIEW_SERVER_URL:-http://mjuclaw-agent:3001}
       - OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1
       - HTTP_PORT=3100
       - HTTP_BIND_HOST=0.0.0.0
@@ -62,6 +63,12 @@ services:
       - CLASSIFIER_URL=${CLASSIFIER_URL:-http://mjuclaw-classifier:3200}
       - CLASSIFIER_AUTH_TOKEN=${CLASSIFIER_AUTH_TOKEN}
       - CLASSIFIER_TIMEOUT_MS=${CLASSIFIER_TIMEOUT_MS:-2500}
+      - PGHOST=${PGHOST:-host.docker.internal}
+      - PGPORT=${PGPORT:-5432}
+      - PGDATABASE=${PGDATABASE:-mjuclaw}
+      - PGUSER=${PGUSER:-mjuclaw_app}
+      - PGPASSWORD=${PGPASSWORD}
+      - PGSCHEMA=${PGSCHEMA:-public_data}
       - MJU_STORAGE=${MJU_STORAGE:-postgres}
       - MJU_PGHOST=${MJU_PGHOST:-${PGHOST:-host.docker.internal}}
       - MJU_PGPORT=${MJU_PGPORT:-${PGPORT:-5432}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       dockerfile: Dockerfile
       additional_contexts:
         mju-cli: ./mju-cli
+        mju-news: ./mju-news
     container_name: mjuclaw-router
     restart: unless-stopped
     extra_hosts:
@@ -77,6 +78,7 @@ services:
       - USER_DATA_ROOT=/data/users
       - OPENCLAW_GATEWAY_URL=${OPENCLAW_GATEWAY_URL:-ws://mjuclaw-agent:18789}
       - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
+      - VIEW_SERVER_URL=${VIEW_SERVER_URL:-http://mjuclaw-agent:3001}
       # docker-compose 내부 네트워크(trusted private)에서만 접근하므로 plaintext ws://
       # 허용. 외부 노출 시 wss:// + 인증서로 전환할 것.
       - OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1
@@ -91,6 +93,13 @@ services:
       - CLASSIFIER_URL=${CLASSIFIER_URL:-http://mjuclaw-classifier:3200}
       - CLASSIFIER_AUTH_TOKEN=${CLASSIFIER_AUTH_TOKEN}
       - CLASSIFIER_TIMEOUT_MS=${CLASSIFIER_TIMEOUT_MS:-2500}
+      # 공개 데이터 Reader(mju-news)가 시간표 설계/졸업 로드맵 공통 DB를 읽는다.
+      - PGHOST=${PGHOST:-host.docker.internal}
+      - PGPORT=${PGPORT:-5432}
+      - PGDATABASE=${PGDATABASE:-mjuclaw}
+      - PGUSER=${PGUSER:-mjuclaw_app}
+      - PGPASSWORD=${PGPASSWORD}
+      - PGSCHEMA=${PGSCHEMA:-public_data}
       # mju-cli postgres 백엔드 (vault read/write를 router도 동일 ROLE로 수행)
       - MJU_STORAGE=${MJU_STORAGE:-postgres}
       - MJU_PGHOST=${MJU_PGHOST:-${PGHOST:-host.docker.internal}}

--- a/test/academic-planning-helper.test.cjs
+++ b/test/academic-planning-helper.test.cjs
@@ -31,6 +31,12 @@ test("dedicated academic planning commands delegate to the shared helper modes",
   assert.match(graduationRoadmap, /exec mju-academic-planning graduation-roadmap "\$@"/);
 });
 
+test("academic planning helper defaults timetable planning to the available first-term catalog window", async () => {
+  const helper = await fs.readFile(path.join(root, "bin", "mju-academic-planning"), "utf8");
+
+  assert.match(helper, /elif month <= 8:\n    print\(f"\{year\} 10"\)/);
+});
+
 function toBashPath(filePath) {
   const normalized = path.resolve(filePath).replace(/\\/g, "/");
   const driveMatch = normalized.match(/^([A-Za-z]):\/(.*)$/);


### PR DESCRIPTION
## 목적\n라우터가 시간표 설계/졸업 로드맵을 OpenClaw 없이 직접 실행할 때 운영 compose에서도 공개 데이터 DB와 view-server에 접근할 수 있게 합니다.\n\n## 변경\n- router build context에 mju-news 추가\n- router 환경에 VIEW_SERVER_URL과 public_data PG* 연결\n- prod compose에도 동일한 runtime env 연결\n- academic-planning helper 기본 시간표 학기를 1학기 카탈로그 사용 기간에 맞춤\n\n## 관련 PR\n- router: https://github.com/university-claw/mjuclaw-router/pull/11\n\n## 검증\n- 
pm.cmd test\n- CI-like env로 docker compose -f docker-compose.yml -f docker-compose.ngrok.yml config --quiet\n- docker compose --env-file release.env.example -f docker-compose.prod.yml config --quiet\n- docker compose --env-file release.env.example -f docker-compose.prod.yml --profile public-data config --quiet\n\n## 배포 순서\n1. router PR merge 후 router image main publish 확인\n2. setup PR merge\n3. setup Production Dry Run / Auto Deploy 확인