### PR TITLE
학사 계획 헬퍼 진단 단계 추가

### DIFF
--- a/bin/mju-academic-planning
+++ b/bin/mju-academic-planning
@@ -6,6 +6,16 @@
 
 set -euo pipefail
 
+MODE="unknown"
+DIAG_STAGE="input"
+DIAG_DETAIL="validation"
+
+diag() {
+  DIAG_STAGE="$1"
+  DIAG_DETAIL="$2"
+  printf 'ACADEMIC_PLANNING_DIAG stage=%s detail=%s mode=%s\n' "$DIAG_STAGE" "$DIAG_DETAIL" "$MODE" >&2
+}
+
 usage() {
   cat >&2 <<'USAGE'
 mju-academic-planning timetable <discord_id> [--year YYYY] [--term-code CODE] [--department DEPT] [--admission-year YYYY] [--student-number NO] [--format json]
@@ -14,15 +24,30 @@ USAGE
 }
 
 die() {
+  printf 'ACADEMIC_PLANNING_DIAG stage=%s detail=%s mode=%s\n' "$DIAG_STAGE" "$DIAG_DETAIL" "$MODE" >&2
   echo "ERR: $*" >&2
   exit 64
 }
 
+fail_stage() {
+  local stage="$1"
+  local detail="$2"
+  local code="${3:-1}"
+  diag "$stage" "$detail"
+  echo "ERR: academic planning failed at $stage.$detail" >&2
+  exit "$code"
+}
+
 need_bin() {
-  command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+  if ! command -v "$1" >/dev/null 2>&1; then
+    DIAG_STAGE="environment"
+    DIAG_DETAIL="$1_missing"
+    die "$1 is required"
+  fi
 }
 
 if [[ $# -lt 2 ]]; then
+  DIAG_DETAIL="missing_arguments"
   usage
   exit 64
 fi
@@ -94,12 +119,16 @@ PY
 }
 
 if [[ "$MODE" == "timetable" && ( -z "$YEAR" || -z "$TERM_CODE" ) ]]; then
+  diag "term" "default_resolve"
   read -r DEFAULT_YEAR DEFAULT_TERM_CODE < <(default_term)
   YEAR="${YEAR:-$DEFAULT_YEAR}"
   TERM_CODE="${TERM_CODE:-$DEFAULT_TERM_CODE}"
 fi
 
-TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/mju-academic-planning.XXXXXX")
+diag "workspace" "tmp_dir_create"
+if ! TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/mju-academic-planning.XXXXXX"); then
+  fail_stage "workspace" "tmp_dir_create_failed"
+fi
 if [[ "${MJU_ACADEMIC_PLANNING_KEEP_TMP:-}" != "1" ]]; then
   trap 'rm -rf "$TMP_DIR"' EXIT
 fi
@@ -116,29 +145,40 @@ INFO_JSON="$TMP_DIR/info.json"
 # final mju-news call below still uses the normal VIEW_API_URL.
 SKIP_VIEW_ENV="${MJU_ACADEMIC_PLANNING_SKIP_VIEW:-1}"
 
+diag "msi" "profile_read"
 if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju --app-dir "$APP_DIR" --format json profile get > "$PROFILE_JSON"; then
+  diag "msi" "profile_read_optional_failed"
   printf '{}\n' > "$PROFILE_JSON"
 fi
 
+diag "msi" "grade_history_read"
 if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju --app-dir "$APP_DIR" --format json msi grade-history > "$GRADE_HISTORY_JSON"; then
+  diag "msi" "grade_history_read_failed"
   echo "ERR: failed to read MSI grade history for academic planning" >&2
   cat "$GRADE_HISTORY_JSON" >&2 2>/dev/null || true
   exit 1
 fi
 
+diag "msi" "current_timetable_read"
 if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju --app-dir "$APP_DIR" --format json msi timetable > "$CURRENT_TIMETABLE_JSON"; then
+  diag "msi" "current_timetable_read_optional_failed"
   printf '{}\n' > "$CURRENT_TIMETABLE_JSON"
 fi
 
 DEPARTMENT_ARGS=("--app-dir" "$APP_DIR" "--format" "json" "msi" "department-timetable")
 if [[ -n "$YEAR" ]]; then DEPARTMENT_ARGS+=("--year" "$YEAR"); fi
 if [[ -n "$TERM_CODE" ]]; then DEPARTMENT_ARGS+=("--term-code" "$TERM_CODE"); fi
+diag "msi" "department_timetable_read_requested_term"
 if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju "${DEPARTMENT_ARGS[@]}" > "$DEPARTMENT_TIMETABLE_JSON"; then
+  diag "msi" "department_timetable_read_requested_term_failed"
+  diag "msi" "department_timetable_read_default_term"
   if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju --app-dir "$APP_DIR" --format json msi department-timetable > "$DEPARTMENT_TIMETABLE_JSON"; then
+    diag "msi" "department_timetable_read_optional_failed"
     printf '{}\n' > "$DEPARTMENT_TIMETABLE_JSON"
   fi
 fi
 
+diag "context" "extract_from_msi"
 EXPLICIT_DEPARTMENT="$DEPARTMENT" \
 EXPLICIT_ADMISSION_YEAR="$ADMISSION_YEAR" \
 EXPLICIT_STUDENT_NUMBER="$STUDENT_NUMBER" \
@@ -148,7 +188,7 @@ CURRENT_TIMETABLE_JSON="$CURRENT_TIMETABLE_JSON" \
 DEPARTMENT_TIMETABLE_JSON="$DEPARTMENT_TIMETABLE_JSON" \
 PERSONAL_JSON="$PERSONAL_JSON" \
 INFO_JSON="$INFO_JSON" \
-python3 - <<'PY'
+python3 - <<'PY' || fail_stage "context" "extract_from_msi_failed"
 import json
 import os
 import re
@@ -280,9 +320,11 @@ DEPARTMENT="$(json_field department)"
 STUDENT_NUMBER="$(json_field studentNumber)"
 ADMISSION_YEAR="$(json_field admissionYear)"
 
-[[ -n "$DEPARTMENT" ]] || die "could not resolve department from MSI data"
+if [[ -z "$DEPARTMENT" ]]; then
+  fail_stage "context" "department_missing" 64
+fi
 if [[ -z "$STUDENT_NUMBER" && -z "$ADMISSION_YEAR" ]]; then
-  die "could not resolve student number or admission year from MSI data"
+  fail_stage "context" "student_identity_missing" 64
 fi
 
 MJU_NEWS_ARGS=("academic-planning" "$MODE" "--department" "$DEPARTMENT" "--format" "json")
@@ -304,4 +346,9 @@ fi
 MJU_NEWS_ARGS+=("--personal-msi-json" "$PERSONAL_JSON")
 MJU_NEWS_ARGS+=("--completed-courses-json" "$GRADE_HISTORY_JSON")
 
-mju-news "${MJU_NEWS_ARGS[@]}"
+diag "public_data" "academic_planning_run"
+if ! mju-news "${MJU_NEWS_ARGS[@]}"; then
+  fail_stage "public_data" "academic_planning_failed"
+fi
+
+diag "success" "output_written"


### PR DESCRIPTION
## 목적\n- setup 이미지 안에서 실행되는 학사 계획 helper도 router와 같은 stage/detail 진단을 내도록 맞춥니다.\n- CD 이후 운영에서 실패 위치를 빠르게 확인하기 위한 변경입니다.\n\n## 변경\n- \mju-academic-planning\에 \ACADEMIC_PLANNING_DIAG stage=... detail=...\ 출력 추가\n- MSI/profile/grade-history/current timetable/department timetable/context/public-data 단계별 실패 지점 구분\n\n## 검증\n- \
pm.cmd test\\n- Git Bash \ash -n bin/mju-academic-planning\\n- helper smoke: \environment.mju_missing\ 진단 출력 확인