### PR TITLE
학사 계획 성적 이력 실패 진단 세분화

### DIFF
--- a/bin/mju-academic-planning
+++ b/bin/mju-academic-planning
@@ -118,6 +118,83 @@ else:
 PY
 }
 
+classify_grade_history_failure() {
+  local stdout_file="$1"
+  local stderr_file="$2"
+  local app_dir="$3"
+  GRADE_HISTORY_STDOUT="$stdout_file" \
+  GRADE_HISTORY_STDERR="$stderr_file" \
+  GRADE_HISTORY_APP_DIR="$app_dir" \
+  python3 - <<'PY'
+import os
+from pathlib import Path
+
+def read(path: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8", errors="ignore")[:1000000]
+    except Exception:
+        return ""
+
+stdout_text = read(os.environ["GRADE_HISTORY_STDOUT"])
+stderr_text = read(os.environ["GRADE_HISTORY_STDERR"])
+app_dir = Path(os.environ["GRADE_HISTORY_APP_DIR"])
+main_html = read(str(app_dir / "snapshots" / "msi-main.html"))
+combined = "\n".join([stdout_text, stderr_text, main_html])
+lower = combined.lower()
+
+def has_password_change_interstitial() -> bool:
+    url_or_code_hit = any(
+        marker in lower
+        for marker in [
+            "password_change_interstitial",
+            "pwchange",
+            "changepw",
+            "change-pw",
+        ]
+    )
+    password_hit = (
+        "password" in lower
+        or "passwd" in lower
+        or "pwd" in lower
+        or "비밀번호" in combined
+    )
+    change_hit = (
+        "change" in lower
+        or "update" in lower
+        or "변경" in combined
+        or "수정" in combined
+    )
+    return url_or_code_hit or (password_hit and change_hit)
+
+if has_password_change_interstitial():
+    print("grade_history_password_change_interstitial_detected")
+elif "[msi.open_menu.main_context_failed]" in combined:
+    print("grade_history_main_context_failed")
+elif "[msi.open_menu.go_body_failed]" in combined:
+    print("grade_history_go_body_failed")
+elif "[msi.open_menu.page_open_failed]" in combined:
+    print("grade_history_page_open_failed")
+elif "저장된 로그인 정보가 없습니다" in combined:
+    print("grade_history_stored_login_missing")
+elif "저장된 비밀번호를 읽지 못했습니다" in combined:
+    print("grade_history_stored_password_unreadable")
+elif "SSO 로그인에 실패" in combined:
+    print("grade_history_sso_login_failed")
+elif "signin-form" in lower or "sso form" in lower:
+    print("grade_history_sso_form_parse_failed")
+elif "callback URL" in combined or "callback url" in lower:
+    print("grade_history_sso_callback_missing")
+elif "code/_csrf" in combined or "code" in lower and "_csrf" in lower:
+    print("grade_history_sso_callback_fields_missing")
+elif "login_security" in lower and "_csrf" in lower:
+    print("grade_history_login_security_csrf_missing")
+elif "csrf" in lower:
+    print("grade_history_csrf_missing")
+else:
+    print("grade_history_unknown_failed")
+PY
+}
+
 if [[ "$MODE" == "timetable" && ( -z "$YEAR" || -z "$TERM_CODE" ) ]]; then
   diag "term" "default_resolve"
   read -r DEFAULT_YEAR DEFAULT_TERM_CODE < <(default_term)
@@ -133,9 +210,10 @@ if [[ "${MJU_ACADEMIC_PLANNING_KEEP_TMP:-}" != "1" ]]; then
   trap 'rm -rf "$TMP_DIR"' EXIT
 fi
 
-APP_DIR="/data/users/$DISCORD_ID"
+APP_DIR="${USER_DATA_ROOT:-/data/users}/$DISCORD_ID"
 PROFILE_JSON="$TMP_DIR/profile.json"
 GRADE_HISTORY_JSON="$TMP_DIR/grade-history.json"
+GRADE_HISTORY_STDERR="$TMP_DIR/grade-history.stderr"
 CURRENT_TIMETABLE_JSON="$TMP_DIR/current-timetable.json"
 DEPARTMENT_TIMETABLE_JSON="$TMP_DIR/department-timetable.json"
 PERSONAL_JSON="$TMP_DIR/personal-msi.json"
@@ -152,9 +230,11 @@ if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju --app-dir "$APP_DIR" --format json profi
 fi
 
 diag "msi" "grade_history_read"
-if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju --app-dir "$APP_DIR" --format json msi grade-history > "$GRADE_HISTORY_JSON"; then
-  diag "msi" "grade_history_read_failed"
+if ! MJU_SKIP_VIEW="$SKIP_VIEW_ENV" mju --app-dir "$APP_DIR" --format json msi grade-history > "$GRADE_HISTORY_JSON" 2> "$GRADE_HISTORY_STDERR"; then
+  DETAIL=$(classify_grade_history_failure "$GRADE_HISTORY_JSON" "$GRADE_HISTORY_STDERR" "$APP_DIR")
+  diag "msi" "$DETAIL"
   echo "ERR: failed to read MSI grade history for academic planning" >&2
+  cat "$GRADE_HISTORY_STDERR" >&2 2>/dev/null || true
   cat "$GRADE_HISTORY_JSON" >&2 2>/dev/null || true
   exit 1
 fi

--- a/test/academic-planning-helper.test.cjs
+++ b/test/academic-planning-helper.test.cjs
@@ -71,6 +71,8 @@ async function createFixture(t) {
 
   const stubBin = path.join(testDir, "bin");
   await fs.mkdir(stubBin, { recursive: true });
+  const usersRoot = path.join(testDir, "users");
+  await fs.mkdir(usersRoot, { recursive: true });
   const mjuCalls = path.join(testDir, "mju-calls.txt");
   const mjuNewsArgs = path.join(testDir, "mju-news-args.txt");
 
@@ -89,6 +91,14 @@ if [[ "\${MJU_SKIP_VIEW:-}" != "1" ]]; then
   exit 3
 fi
 printf '%s\\n' "$*" >> "${toBashPath(mjuCalls)}"
+APP_DIR=""
+previous=""
+for arg in "$@"; do
+  if [[ "$previous" == "--app-dir" ]]; then
+    APP_DIR="$arg"
+  fi
+  previous="$arg"
+done
 joined=" $* "
 case "$joined" in
   *" profile get"*)
@@ -97,6 +107,16 @@ case "$joined" in
 JSON
     ;;
   *" msi grade-history"*)
+    if [[ "\${MJU_STUB_GRADE_HISTORY_FAILURE:-}" == "main_context" ]]; then
+      echo '{"error":{"message":"[msi.open_menu.main_context_failed] missing csrf"}}' >&2
+      exit 1
+    fi
+    if [[ "\${MJU_STUB_GRADE_HISTORY_FAILURE:-}" == "password_change" ]]; then
+      mkdir -p "$APP_DIR/snapshots"
+      printf '%s\\n' '<html><body>비밀번호 변경</body></html>' > "$APP_DIR/snapshots/msi-main.html"
+      echo '{"error":{"message":"[msi.login.password_change_interstitial_detected] MSI login landed on a password-change interstitial"}}' >&2
+      exit 1
+    fi
     cat <<'JSON'
 {"studentInfo":{"학과":"컴퓨터공학과","학번":"202112345"},"termRecords":[{"year":2021,"termLabel":"1학기","courses":[{"courseTitle":"미적분학1","courseCode":"KME02101","credit":3,"categoryLabel":"학문기초교양"}]}]}
 JSON
@@ -127,14 +147,19 @@ printf '{"viewUrl":"http://view.local/%s","ok":true}\\n' "\${2:-unknown}"
 `, "utf8");
   await fs.chmod(mjuNewsStub, 0o755);
 
-  return { stubBin, mjuCalls, mjuNewsArgs };
+  return { stubBin, usersRoot, mjuCalls, mjuNewsArgs };
 }
 
-async function runHelper(fixture, args) {
+async function runHelper(fixture, args, env = {}) {
   const helper = toBashPath(path.join(root, "bin", "mju-academic-planning"));
+  const envPrefix = Object.entries(env).map(
+    ([key, value]) => `${key}=${shellQuote(value)}`
+  );
   const command = [
     `PATH=${shellQuote(toBashPath(fixture.stubBin))}:$PATH`,
     "MJU_ACADEMIC_PLANNING_KEEP_TMP=1",
+    `USER_DATA_ROOT=${shellQuote(toBashPath(fixture.usersRoot))}`,
+    ...envPrefix,
     shellQuote(helper),
     ...args.map(shellQuote),
   ].join(" ");
@@ -208,4 +233,38 @@ bashTest("academic planning helper routes timetable generation without UCheck", 
   assert.match(mjuCalls, /msi grade-history/);
   assert.match(mjuCalls, /msi department-timetable/);
   assert.doesNotMatch(mjuCalls, /ucheck/);
+});
+
+bashTest("academic planning helper reports a specific grade-history menu context failure", async (t) => {
+  const fixture = await createFixture(t);
+  const result = await runHelper(
+    fixture,
+    [
+      "graduation-roadmap",
+      "123456789012345678",
+      "--format",
+      "json",
+    ],
+    { MJU_STUB_GRADE_HISTORY_FAILURE: "main_context" }
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /ACADEMIC_PLANNING_DIAG stage=msi detail=grade_history_main_context_failed/);
+});
+
+bashTest("academic planning helper reports a password-change interstitial candidate", async (t) => {
+  const fixture = await createFixture(t);
+  const result = await runHelper(
+    fixture,
+    [
+      "graduation-roadmap",
+      "123456789012345678",
+      "--format",
+      "json",
+    ],
+    { MJU_STUB_GRADE_HISTORY_FAILURE: "password_change" }
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /ACADEMIC_PLANNING_DIAG stage=msi detail=grade_history_password_change_interstitial_detected/);
 });


### PR DESCRIPTION
## 왜 하는가\n운영에서 시간표 설계/졸업로드맵이 실패할 때 grade_history_read_failed만 보여 로그인, 비밀번호 변경 안내, MSI 메뉴 진입, 파싱 문제를 구분할 수 없습니다.\n\n## 변경\n- academic planning helper가 grade-history 실패 stderr와 MSI main snapshot을 분류합니다.\n- Discord에 노출되는 diagnostic detail을 grade_history_password_change_interstitial_detected, grade_history_main_context_failed, grade_history_go_body_failed 등으로 세분화합니다.\n- helper 테스트 스텁에 세부 실패 케이스를 추가했습니다.\n\n## 검증\n- npm test\n- bash -n은 로컬 WSL bash 부재로 직접 실행 불가