### PR TITLE
졸업 로드맵 자유선택 인정 학점 보정

### DIFF
--- a/src/view-renderer.ts
+++ b/src/view-renderer.ts
@@ -5860,7 +5860,7 @@ function graduationMoreButton(
   const hiddenCount = rows.filter((row) => row.moreHidden).length;
   const potentialCount = rows.filter((row) => !row.choicePrompt).length;
   if (hiddenCount === 0 && potentialCount <= GRADUATION_MORE_BATCH_SIZE) return "";
-  return `<button class="grad-more-button" type="button" data-grad-more data-grad-more-batch="${GRADUATION_MORE_BATCH_SIZE}"${hiddenCount ? "" : " hidden"}>${GRADUATION_MORE_BATCH_SIZE}개 더보기</button>`;
+  return `<button class="grad-more-button" type="button" data-grad-more data-grad-more-batch="${GRADUATION_MORE_BATCH_SIZE}"${hiddenCount ? "" : " hidden"}>더보기</button>`;
 }
 
 function renderGraduationSourceSummary(
@@ -6315,7 +6315,7 @@ const updateMore = (body) => {
   }
   if (button) {
     button.hidden = hidden === 0;
-    button.textContent = batch + "개 더보기";
+    button.textContent = "더보기";
   }
 };
 const syncChoices = (resetMore) => {
@@ -6856,11 +6856,51 @@ function graduationCourseMatchesSectionScore(course: GraduationCourseRef, sectio
   return 0;
 }
 
+function graduationBestRequiredSection(
+  sections: GraduationRequirementSection[],
+  predicate: (section: GraduationRequirementSection) => boolean,
+): GraduationRequirementSection | undefined {
+  return sections
+    .filter(predicate)
+    .sort((a, b) => (graduationCreditNumber(b.required) ?? 0) - (graduationCreditNumber(a.required) ?? 0))[0];
+}
+
+function graduationCappedSectionCredits(section: GraduationRequirementSection | undefined): number {
+  if (!section) return 0;
+  const earned = graduationCreditNumber(section.earned) ?? 0;
+  const required = graduationCreditNumber(section.required);
+  return required == null ? earned : Math.min(earned, required);
+}
+
+function graduationResidualFreeElectiveCredits(
+  sections: GraduationRequirementSection[],
+  completedCourses: GraduationCourseRef[],
+): number {
+  const totalSection = sections.find(graduationSectionLooksLikeTotal);
+  const totalEarned = graduationCreditNumber(totalSection?.earned) ??
+    completedCourses.reduce((sum, course) => sum + graduationCourseCredit(course), 0);
+  if (!totalEarned) return 0;
+
+  const majorSection = graduationBestRequiredSection(
+    sections,
+    (section) => !graduationFreeElectiveSection(section) && graduationMajorSection(section),
+  );
+  const liberalSection = sections.find(graduationSectionLooksLikeLiberalCreditRollup) ??
+    graduationBestRequiredSection(
+      sections,
+      (section) => !graduationFreeElectiveSection(section) && /교양|liberal/i.test(section.label),
+    );
+
+  const allocated = graduationCappedSectionCredits(majorSection) +
+    graduationCappedSectionCredits(liberalSection);
+  return Math.max(0, totalEarned - allocated);
+}
+
 function graduationApplyCompletedCourses(
   creditGaps: GraduationRequirementSection[],
   completedCourses: GraduationCourseRef[],
 ): GraduationRequirementSection[] {
-  if (!completedCourses.length || !creditGaps.length) return creditGaps;
+  if (!creditGaps.length) return creditGaps;
 
   // Graduation roadmap readers can provide official requirements and taken-course history
   // as separate top-level payloads. The view must merge them before rendering area cards.
@@ -6870,20 +6910,22 @@ function graduationApplyCompletedCourses(
   }));
   const assignments = new Map<number, GraduationCourseRef[]>();
 
-  completedCourses.forEach((course) => {
-    let bestIndex = -1;
-    let bestScore = 0;
-    sections.forEach((section, index) => {
-      if (graduationSectionLooksLikeTotal(section)) return;
-      const score = graduationCourseMatchesSectionScore(course, section);
-      if (score > bestScore) {
-        bestIndex = index;
-        bestScore = score;
-      }
+  if (completedCourses.length) {
+    completedCourses.forEach((course) => {
+      let bestIndex = -1;
+      let bestScore = 0;
+      sections.forEach((section, index) => {
+        if (graduationSectionLooksLikeTotal(section)) return;
+        const score = graduationCourseMatchesSectionScore(course, section);
+        if (score > bestScore) {
+          bestIndex = index;
+          bestScore = score;
+        }
+      });
+      if (bestIndex < 0 || bestScore <= 0) return;
+      assignments.set(bestIndex, [...(assignments.get(bestIndex) ?? []), course]);
     });
-    if (bestIndex < 0 || bestScore <= 0) return;
-    assignments.set(bestIndex, [...(assignments.get(bestIndex) ?? []), course]);
-  });
+  }
 
   sections.forEach((section, index) => {
     const completed = assignments.get(index) ?? [];
@@ -6918,6 +6960,16 @@ function graduationApplyCompletedCourses(
     const required = graduationCreditNumber(totalSection.required);
     const earned = graduationCreditNumber(totalSection.earned);
     if (required != null && earned != null) totalSection.gap = Math.max(0, required - earned);
+  }
+
+  const freeElectiveSection = sections.find(graduationFreeElectiveSection);
+  if (freeElectiveSection) {
+    const residualCredits = graduationResidualFreeElectiveCredits(sections, completedCourses);
+    const currentEarned = graduationCreditNumber(freeElectiveSection.earned) ?? 0;
+    if (residualCredits > currentEarned) freeElectiveSection.earned = residualCredits;
+    const required = graduationCreditNumber(freeElectiveSection.required);
+    const earned = graduationCreditNumber(freeElectiveSection.earned);
+    if (required != null && earned != null) freeElectiveSection.gap = Math.max(0, required - earned);
   }
 
   return sections;

--- a/test/graduation-renderer.test.cjs
+++ b/test/graduation-renderer.test.cjs
@@ -551,6 +551,26 @@ test("graduation explains free elective shortages as recognized elective credits
   assert.match(html, /미수강/);
 });
 
+test("graduation counts surplus major and liberal credits toward free elective credits", () => {
+  const html = renderViewHtml({
+    ...graduationEntry(),
+    rawData: {
+      department: "Computer Engineering",
+      admissionYear: 2021,
+      creditGaps: [
+        { label: "Total Credits", earned: 130, required: 134, gap: 4 },
+        { label: "Major Credits", earned: 76, required: 74, gap: 0 },
+        { label: "Liberal Credits", earned: 52, required: 48, gap: 0 },
+        { label: "Free Elective", earned: 0, required: 12, gap: 12 },
+      ],
+    },
+  });
+
+  const freeElectiveCard = graduationAreaCardHtml(html, "Free Elective");
+  assert.match(freeElectiveCard, /8 \/ 12/);
+  assert.match(freeElectiveCard, /4학점 부족/);
+});
+
 test("graduation summarizes major credit shortages without inventing missing electives", () => {
   const html = renderViewHtml({
     ...graduationEntry(),
@@ -1637,7 +1657,7 @@ test("graduation collapses large major course lists in batches without hiding of
   assert.match(html, /data-grad-more/);
   assert.match(html, /\[hidden\]\s*\{\s*display:\s*none !important;/);
   assert.match(html, /\.grad-course-detail-row\[hidden\]\s*\{\s*display:\s*none !important;/);
-  assert.match(html, /10개 더보기/);
+  assert.match(html, /더보기/);
   assert.doesNotMatch(graduationCourseRowHtml(html, "Major elective 10"), /hidden/);
   assert.match(graduationCourseRowHtml(html, "Major elective 11"), /hidden/);
   assert.match(graduationCourseRowHtml(html, "Major elective 12"), /hidden/);
@@ -1668,7 +1688,7 @@ test("graduation collapses large non-major area course lists in batches", () => 
   });
 
   assert.match(html, /data-grad-more/);
-  assert.match(html, /10개 더보기/);
+  assert.match(html, /더보기/);
   assert.doesNotMatch(graduationCourseRowHtml(html, "Common liberal 10"), /hidden/);
   assert.match(graduationCourseRowHtml(html, "Common liberal 11"), /hidden/);
   assert.match(graduationCourseRowHtml(html, "Common liberal 12"), /hidden/);


### PR DESCRIPTION
## 왜 하는가

졸업 로드맵에서 총 취득학점과 전공/교양 학점은 맞게 들어오는데 자유선택이 `0 / 12`로 남아 사용자가 실제 부족 학점을 오해할 수 있습니다. 컴퓨터공학전공 공식 이수가이드의 2018년 이후 공학인증 기준은 교양 48, 전공 74, 자유선택 12, 총 134로 나뉘며, 명지대 답변에서도 자유선택은 전공초과/학문기초교양 초과/일반교양 등 인정 잔여 학점 성격으로 설명됩니다.

## 변경

- 졸업 로드맵에서 총 취득학점 기준으로 전공/교양 최소요건에 먼저 배정하고 남는 학점을 자유선택 인정 학점으로 계산합니다.
- 중복된 공통/핵심/학문기초 하위영역을 다시 빼지 않고, 전공 rollup과 교양학점 rollup만 cap 처리합니다.
- 졸업 로드맵 상세의 `10개 더보기` 문구를 `더보기`로 줄였습니다.

## 공식 근거

- 컴퓨터공학전공 졸업이수가이드: 2018년 이후 공학인증 `교양학점 48 / 전공학점 74 / 자유선택 12 / 최소이수학점 134`
- 명지대 Q&A: 자유선택학점은 전공초과학점, 학문기초교양 초과학점, 일반교양 학점으로 계산된다는 답변

## 검증

- `npm.cmd run build`
- `node --test test\\graduation-renderer.test.cjs`
- `node --test test\\view-server-datatypes.test.cjs`
- `npm.cmd test`

## 배포 순서

시간표 전공 강좌 누락 복구는 reader PR이 선행되어야 합니다. reader PR 머지 후 이 PR을 머지하면 setup CD가 reader main까지 포함해서 이미지를 빌드합니다.