### PR TITLE
시간표/로드맵 helper 진단 웹뷰 경로 고정

### DIFF
--- a/bin/mju-academic-planning
+++ b/bin/mju-academic-planning
@@ -102,6 +102,7 @@ done
 need_bin mju
 need_bin mju-news
 need_bin python3
+need_bin curl
 
 default_term() {
   python3 - <<'PY'
@@ -397,6 +398,8 @@ INFO_JSON="$TMP_DIR/info.json"
 CONTEXT_STDERR="$TMP_DIR/context.stderr"
 MJU_NEWS_STDOUT="$TMP_DIR/mju-news.stdout"
 MJU_NEWS_STDERR="$TMP_DIR/mju-news.stderr"
+MJU_NEWS_ENRICHED_JSON="$TMP_DIR/mju-news.enriched.json"
+VIEW_REQUEST_BODY="$TMP_DIR/view-request-body.json"
 
 SKIP_VIEW_ENV="${MJU_ACADEMIC_PLANNING_SKIP_VIEW:-1}"
 
@@ -637,8 +640,10 @@ fi
 MJU_NEWS_ARGS+=("--personal-msi-json" "$PERSONAL_JSON")
 MJU_NEWS_ARGS+=("--completed-courses-json" "$GRADE_HISTORY_JSON")
 
+MJU_NEWS_PATH="$(command -v mju-news || true)"
+
 diag "public_data" "academic_planning_run"
-if ! mju-news "${MJU_NEWS_ARGS[@]}" > "$MJU_NEWS_STDOUT" 2> "$MJU_NEWS_STDERR"; then
+if ! MJU_NEWS_SKIP_VIEW=1 mju-news "${MJU_NEWS_ARGS[@]}" > "$MJU_NEWS_STDOUT" 2> "$MJU_NEWS_STDERR"; then
   DETAIL=$(classify_public_data_failure "$MJU_NEWS_STDOUT" "$MJU_NEWS_STDERR")
   diag "public_data" "$DETAIL"
   echo "ERR: failed to build academic planning payload" >&2
@@ -646,6 +651,209 @@ if ! mju-news "${MJU_NEWS_ARGS[@]}" > "$MJU_NEWS_STDOUT" 2> "$MJU_NEWS_STDERR"; 
   cat "$MJU_NEWS_STDOUT" >&2 2>/dev/null || true
   exit 1
 fi
-cat "$MJU_NEWS_STDOUT"
+
+case "$MODE" in
+  timetable)
+    VIEW_DATA_TYPE="timetable-planner"
+    VIEW_TITLE="시간표 설계"
+    ;;
+  graduation-roadmap)
+    VIEW_DATA_TYPE="graduation"
+    VIEW_TITLE="졸업 로드맵"
+    ;;
+  *)
+    VIEW_DATA_TYPE="academic-planning"
+    VIEW_TITLE="학사 계획"
+    ;;
+esac
+
+diag "public_data" "academic_planning_enrich"
+if ! PYTHONIOENCODING=utf-8 \
+  RAW_STDOUT_FILE="$MJU_NEWS_STDOUT" \
+  ENRICHED_STDOUT_FILE="$MJU_NEWS_ENRICHED_JSON" \
+  MODE="$MODE" \
+  VIEW_DATA_TYPE="$VIEW_DATA_TYPE" \
+  MJU_NEWS_PATH="$MJU_NEWS_PATH" \
+  DEPARTMENT="$DEPARTMENT" \
+  YEAR="$YEAR" \
+  TERM_CODE="$TERM_CODE" \
+  ADMISSION_YEAR="$ADMISSION_YEAR" \
+  STUDENT_NUMBER_PROVIDED="$([[ -n "$STUDENT_NUMBER" ]] && echo true || echo false)" \
+  STUDENT_TYPE="$STUDENT_TYPE" \
+  GRADUATION_TERM="$GRADUATION_TERM" \
+  python3 - <<'PY'
+import json
+import os
+from datetime import datetime, timezone
+
+
+def source_lengths(data):
+    result = {}
+    for key in ("entries", "items", "courses", "catalog"):
+        value = data.get(key)
+        result[key] = len(value) if isinstance(value, list) else 0
+    return result
+
+
+def first_source_key(lengths):
+    for key in ("entries", "items", "courses", "catalog"):
+        if lengths.get(key, 0) > 0:
+            return key
+    return "none"
+
+
+with open(os.environ["RAW_STDOUT_FILE"], encoding="utf-8") as handle:
+    raw = handle.read()
+
+try:
+    parsed = json.loads(raw)
+except Exception:
+    parsed = None
+
+if isinstance(parsed, dict):
+    data = parsed
+else:
+    data = {"rawOutput": raw}
+
+existing_view_url = data.pop("viewUrl", None)
+lengths = source_lengths(data)
+payload_diagnostics = data.get("payloadDiagnostics")
+catalog_diagnostics = data.get("courseCatalogDiagnostics") or data.get("catalogDiagnostics")
+wrapper_diagnostics = data.get("wrapperDiagnostics")
+data_readiness = data.get("dataReadiness")
+top_level_keys = sorted(str(key) for key in data.keys())
+
+hints = []
+if existing_view_url:
+    hints.append("mju-news output already had a viewUrl; helper replaced it with a fresh helper-owned webview.")
+if not isinstance(wrapper_diagnostics, dict):
+    hints.append("mju-news wrapperDiagnostics is missing; helper-owned diagnostics were attached after the reader call.")
+if not isinstance(payload_diagnostics, dict):
+    hints.append("reader payloadDiagnostics is missing from academic-planning output.")
+if os.environ.get("MODE") == "timetable" and not isinstance(catalog_diagnostics, dict):
+    hints.append("courseCatalogDiagnostics is missing, so DB/filter/category stages are not visible yet.")
+
+data["academicPlanningHelperDiagnostics"] = {
+    "diagnosticVersion": 1,
+    "generatedAt": datetime.now(timezone.utc).isoformat(),
+    "producer": "mju-academic-planning-helper",
+    "mode": os.environ.get("MODE", ""),
+    "dataType": os.environ.get("VIEW_DATA_TYPE", ""),
+    "runtime": {
+        "script": "mju-academic-planning",
+        "mjuNewsPath": os.environ.get("MJU_NEWS_PATH", ""),
+        "skipNestedMjuNewsView": True,
+    },
+    "context": {
+        "department": os.environ.get("DEPARTMENT", ""),
+        "year": os.environ.get("YEAR", ""),
+        "termCode": os.environ.get("TERM_CODE", ""),
+        "admissionYear": os.environ.get("ADMISSION_YEAR", ""),
+        "studentNumberProvided": os.environ.get("STUDENT_NUMBER_PROVIDED", ""),
+        "studentType": os.environ.get("STUDENT_TYPE", ""),
+        "graduationTerm": os.environ.get("GRADUATION_TERM", ""),
+    },
+    "mjuNewsOutput": {
+        "hadViewUrl": bool(existing_view_url),
+        "hasWrapperDiagnostics": isinstance(wrapper_diagnostics, dict),
+        "hasPayloadDiagnostics": isinstance(payload_diagnostics, dict),
+        "hasCourseCatalogDiagnostics": isinstance(catalog_diagnostics, dict),
+        "hasDataReadiness": isinstance(data_readiness, list),
+        "topLevelKeyCount": len(top_level_keys),
+        "sourceKey": first_source_key(lengths),
+        **{f"{key}Count": count for key, count in lengths.items()},
+    },
+    "topLevelKeys": top_level_keys[:80],
+    "hints": hints,
+}
+
+with open(os.environ["ENRICHED_STDOUT_FILE"], "w", encoding="utf-8") as handle:
+    json.dump(data, handle, ensure_ascii=False)
+PY
+then
+  fail_stage "public_data" "academic_planning_enrich_failed"
+fi
+
+diag "view" "request_build"
+if ! PYTHONIOENCODING=utf-8 \
+  RAW_STDOUT_FILE="$MJU_NEWS_ENRICHED_JSON" \
+  VIEW_DATA_TYPE="$VIEW_DATA_TYPE" \
+  VIEW_TITLE="$VIEW_TITLE" \
+  VIEW_REQUEST_BODY="$VIEW_REQUEST_BODY" \
+  python3 - <<'PY'
+import json
+import os
+
+with open(os.environ["RAW_STDOUT_FILE"], encoding="utf-8") as handle:
+    raw = handle.read()
+
+try:
+    data = json.loads(raw)
+except Exception:
+    data = {"rawOutput": raw}
+
+with open(os.environ["VIEW_REQUEST_BODY"], "w", encoding="utf-8") as handle:
+    json.dump({
+        "dataType": os.environ["VIEW_DATA_TYPE"],
+        "title": os.environ["VIEW_TITLE"],
+        "summary": "",
+        "rawData": data,
+        "aiResponse": "",
+    }, handle, ensure_ascii=False)
+PY
+then
+  fail_stage "view" "request_build_failed"
+fi
+
+diag "view" "post"
+set +e
+VIEW_RESP=$(curl -s --max-time 3 -X POST "${VIEW_API_URL:-http://localhost:3001/api/view}" \
+  -H "Content-Type: application/json" \
+  --data-binary @"$VIEW_REQUEST_BODY" 2>/dev/null)
+CURL_EXIT=$?
+set -e
+
+if [[ $CURL_EXIT -ne 0 ]]; then
+  diag "view" "post_failed"
+  cat "$MJU_NEWS_ENRICHED_JSON"
+  printf '\n'
+  exit 0
+fi
+
+VIEW_URL=$(PYTHONIOENCODING=utf-8 VIEW_RESP="$VIEW_RESP" python3 - <<'PY'
+import json
+import os
+
+try:
+    print(json.loads(os.environ["VIEW_RESP"]).get("url", ""))
+except Exception:
+    pass
+PY
+)
+
+if [[ -n "$VIEW_URL" ]]; then
+  PYTHONIOENCODING=utf-8 RAW_STDOUT_FILE="$MJU_NEWS_ENRICHED_JSON" VIEW_URL="$VIEW_URL" python3 - <<'PY'
+import json
+import os
+
+with open(os.environ["RAW_STDOUT_FILE"], encoding="utf-8") as handle:
+    raw = handle.read()
+view_url = os.environ["VIEW_URL"]
+
+try:
+    data = json.loads(raw)
+    if isinstance(data, dict):
+        data["viewUrl"] = view_url
+        print(json.dumps(data, ensure_ascii=False))
+    else:
+        print(json.dumps({"data": data, "viewUrl": view_url}, ensure_ascii=False))
+except Exception:
+    print(raw)
+PY
+else
+  diag "view" "post_response_missing_url"
+  cat "$MJU_NEWS_ENRICHED_JSON"
+  printf '\n'
+fi
 
 diag "success" "output_written"

--- a/bin/mju-news
+++ b/bin/mju-news
@@ -93,6 +93,11 @@ if [[ -n "$STDERR" ]]; then
 fi
 
 # 실패·view 대상 아님·JSON 아님이면 pass-through
+if [[ "${MJU_NEWS_SKIP_VIEW:-}" == "1" ]]; then
+  printf '%s\n' "$STDOUT"
+  exit "$EXIT"
+fi
+
 if [[ $EXIT -ne 0 ]] || ! should_view "$@"; then
   printf '%s\n' "$STDOUT"
   exit "$EXIT"

--- a/src/view-renderer.ts
+++ b/src/view-renderer.ts
@@ -3189,6 +3189,15 @@ type PlannerWrapperDiagnostics = {
   hints: string[];
 };
 
+type PlannerHelperDiagnostics = {
+  summary: string;
+  stages: PlannerDiagnosticStage[];
+  runtime: PlannerDiagnosticBucket[];
+  context: PlannerDiagnosticBucket[];
+  topLevelKeys: string[];
+  hints: string[];
+};
+
 type PlannerPayloadDiagnostics = {
   producer: string;
   diagnosticVersion?: string;
@@ -3224,6 +3233,7 @@ type PlannerUiDiagnostics = {
 
 type TimetablePlannerDiagnostics = {
   payload: PlannerPayloadDiagnostics;
+  helper?: PlannerHelperDiagnostics;
   wrapper?: PlannerWrapperDiagnostics;
   reader?: PlannerReaderDiagnostics;
   ui: PlannerUiDiagnostics;
@@ -3419,8 +3429,12 @@ function renderPlannerSearchPanel(): string {
 
 function renderPlannerDiagnostics(diagnostics: TimetablePlannerDiagnostics): string {
   const reader = diagnostics.reader;
+  const helper = diagnostics.helper;
   const wrapper = diagnostics.wrapper;
   const payload = diagnostics.payload;
+  const helperStages = helper?.stages.length
+    ? helper.stages.map(renderPlannerDiagnosticStage).join("")
+    : `<div class="planner-diag-empty">helper 진단 payload가 없습니다.</div>`;
   const wrapperStages = wrapper?.stages.length
     ? wrapper.stages.map(renderPlannerDiagnosticStage).join("")
     : `<div class="planner-diag-empty">wrapper 진단 payload가 없습니다.</div>`;
@@ -3436,6 +3450,7 @@ function renderPlannerDiagnostics(diagnostics: TimetablePlannerDiagnostics): str
     { key: "ui.initialSchedule", label: "초기 시간표", count: diagnostics.ui.initialSchedule, status: diagnostics.ui.initialSchedule ? "ok" as const : "empty" as const },
   ].map(renderPlannerDiagnosticStage).join("");
   const hints = [
+    ...(helper?.hints ?? []),
     ...(wrapper?.hints ?? []),
     ...payload.hints,
     ...(reader?.hints ?? []),
@@ -3445,7 +3460,7 @@ function renderPlannerDiagnostics(diagnostics: TimetablePlannerDiagnostics): str
   return `<div class="planner-diagnostics" data-planner-diagnostics>
     <div class="planner-diag-head">
       <div><strong>임시 진단 카드</strong><span>시간표 누락 원인을 찾기 위한 숫자입니다. 확인 후 제거할 수 있습니다.</span></div>
-      <small>${esc(joinMeta([wrapper?.summary, payload.producer, reader?.source, reader?.scope]))}</small>
+      <small>${esc(joinMeta([helper?.summary, wrapper?.summary, payload.producer, reader?.source, reader?.scope]))}</small>
     </div>
     <div class="planner-diag-section"><h3>payload 경로</h3><div class="planner-diag-grid">
       ${renderPlannerDiagnosticStage({ key: "payload.producer", label: payload.producer || "producer 없음", count: payload.diagnosticVersion ? Number(payload.diagnosticVersion) || 1 : 0, status: payload.producer ? "ok" : "empty" })}
@@ -3484,6 +3499,11 @@ function renderPlannerDiagnostics(diagnostics: TimetablePlannerDiagnostics): str
       ${renderPlannerDiagnosticSamples("reader allTerm sample", reader?.samples.allTerm)}
       ${renderPlannerDiagnosticSamples("reader department sample", reader?.samples.departmentMatched)}
       ${renderPlannerDiagnosticSamples("reader output sample", reader?.samples.readerOutput)}
+    </div></div>
+    <div class="planner-diag-section"><h3>helper 실행</h3><div class="planner-diag-grid">${helperStages}</div><div class="planner-diag-buckets">
+      ${renderPlannerDiagnosticBuckets("helper runtime", helper?.runtime)}
+      ${renderPlannerDiagnosticBuckets("helper context", helper?.context, 12)}
+      ${renderPlannerDiagnosticBuckets("helper rawData keys", helper?.topLevelKeys.map((key) => ({ key, count: 1 })), 14)}
     </div></div>
     ${hints.length ? `<div class="planner-diag-hints">${hints.map((hint) => `<p>${esc(hint)}</p>`).join("")}</div>` : ""}
   </div>`;
@@ -3775,6 +3795,7 @@ function buildTimetablePlannerDiagnostics(
   }
 
   const payload = buildPlannerPayloadDiagnostics(rawData, args.rawCourses, args.rawSourceKey);
+  const helper = normalizePlannerHelperDiagnostics(rawData.academicPlanningHelperDiagnostics);
   const wrapper = normalizePlannerWrapperDiagnostics(rawData.wrapperDiagnostics);
   const reader = normalizePlannerReaderDiagnostics(rawData.courseCatalogDiagnostics ?? rawData.catalogDiagnostics);
   uiHints.push(...plannerRootCauseHints({
@@ -3783,12 +3804,14 @@ function buildTimetablePlannerDiagnostics(
     courses: args.courses,
     selectableCourses: args.selectableCourses,
     payload,
+    helper,
     wrapper,
     reader,
   }));
 
   return {
     payload,
+    helper,
     wrapper,
     reader,
     ui: {
@@ -3815,6 +3838,7 @@ function plannerRootCauseHints(args: {
   courses: PlannerCourse[];
   selectableCourses: PlannerCourse[];
   payload: PlannerPayloadDiagnostics;
+  helper?: PlannerHelperDiagnostics;
   wrapper?: PlannerWrapperDiagnostics;
   reader?: PlannerReaderDiagnostics;
 }): string[] {
@@ -3824,19 +3848,20 @@ function plannerRootCauseHints(args: {
   const afterCompletedHasMajor = args.courses.some((course) => course.category === "major");
   const selectableHasMajor = args.selectableCourses.some((course) => course.category === "major");
   const wrapperPayloadOk = args.wrapper?.stages.some((stage) => stage.key.endsWith(".hasPayloadDiagnostics") && stage.status === "ok");
-  const wrapperCatalogOk = args.wrapper?.stages.some((stage) => stage.key.endsWith(".hasCourseCatalogDiagnostics") && stage.status === "ok");
   const readerAllTermHasMajor = args.reader?.categoryCounts.allTerm.some(plannerDiagnosticBucketLooksMajor) ?? false;
   const readerDepartmentHasMajor = args.reader?.categoryCounts.departmentMatched.some(plannerDiagnosticBucketLooksMajor) ?? false;
   const readerOutputHasMajor = args.reader?.categoryCounts.readerOutput.some(plannerDiagnosticBucketLooksMajor) ?? false;
 
-  if (!args.wrapper) {
+  if (!args.wrapper && args.helper) {
+    hints.push("(여기 H0) academic-planning helper가 최종 웹뷰를 만들었지만 mju-news wrapper 진단은 없습니다. 전용 helper 경로에서 nested mju-news view 생성을 건너뛰고 helper-owned view로 저장한 상태입니다.");
+  } else if (!args.wrapper) {
     hints.push("(여기 W0) wrapper 진단이 없습니다. 새 배포 이전에 생성된 웹뷰이거나 wrapper를 거치지 않은 저장 경로입니다.");
   } else if (!wrapperPayloadOk) {
     hints.push("(여기 W1) wrapper는 실행됐지만 reader payloadDiagnostics가 없습니다. 최신 setup은 떴지만 실행된 reader가 오래됐거나 다른 mju-news 경로를 탔는지 확인해야 합니다.");
   }
 
   if (!rawHasMajor) {
-    if (!args.reader || !wrapperCatalogOk) {
+    if (!args.reader) {
       hints.push("(여기 M0) raw 강의 배열에 전공이 없고 reader 상세 진단도 없습니다. 현재 payload만으로는 DB 누락과 학과 필터 실패를 구분할 수 없습니다.");
     } else if (!readerAllTermHasMajor) {
       hints.push("(여기 M1) DB/JSON의 해당 연도·학기 전체에도 전공 분류가 없습니다. 개설강좌 수집/import가 교양만 넣었거나 전공 category 수집이 누락된 상태입니다.");
@@ -4070,6 +4095,28 @@ function normalizePlannerReaderDiagnostics(value: unknown): PlannerReaderDiagnos
       departmentMatched: normalizePlannerDiagnosticSamples(unknownRecord(record.samples).departmentMatched),
       readerOutput: normalizePlannerDiagnosticSamples(unknownRecord(record.samples).readerOutput),
     },
+    hints: unknownStringArray(record.hints),
+  };
+}
+
+function normalizePlannerHelperDiagnostics(value: unknown): PlannerHelperDiagnostics | undefined {
+  const record = unknownRecord(value);
+  if (!Object.keys(record).length) return undefined;
+  const runtime = unknownRecord(record.runtime);
+  const context = unknownRecord(record.context);
+  const output = unknownRecord(record.mjuNewsOutput);
+  const summary = joinMeta([
+    stringFrom(record.producer) || "mju-academic-planning-helper",
+    stringFrom(record.mode),
+    stringFrom(record.dataType),
+    stringFrom(record.generatedAt),
+  ]);
+  return {
+    summary,
+    stages: plannerPayloadOutputStages(output, "helper.mjuNews"),
+    runtime: plannerDiagnosticBucketsFromRecord(runtime),
+    context: plannerDiagnosticBucketsFromRecord(context),
+    topLevelKeys: unknownStringArray(record.topLevelKeys),
     hints: unknownStringArray(record.hints),
   };
 }

--- a/test/academic-planning-helper.test.cjs
+++ b/test/academic-planning-helper.test.cjs
@@ -80,6 +80,7 @@ async function createFixture(t) {
   await fs.mkdir(usersRoot, { recursive: true });
   const mjuCalls = path.join(testDir, "mju-calls.txt");
   const mjuNewsArgs = path.join(testDir, "mju-news-args.txt");
+  const viewRequest = path.join(testDir, "view-request.json");
 
   const python3Stub = path.join(stubBin, "python3");
   await fs.writeFile(python3Stub, `#!/usr/bin/env bash
@@ -117,8 +118,8 @@ JSON
       exit 1
     fi
     if [[ "\${MJU_STUB_GRADE_HISTORY_FAILURE:-}" == "password_change" ]]; then
-      mkdir -p "$APP_DIR/snapshots"
-      printf '%s\\n' '<html><body>비밀번호 변경</body></html>' > "$APP_DIR/snapshots/msi-main.html"
+      mkdir -p "$APP_DIR/snapshots" 2>/dev/null || true
+      [[ -d "$APP_DIR/snapshots" ]] && printf '%s\\n' '<html><body>비밀번호 변경</body></html>' > "$APP_DIR/snapshots/msi-main.html" || true
       echo '{"error":{"message":"[msi.login.password_change_interstitial_detected] MSI login landed on a password-change interstitial"}}' >&2
       exit 1
     fi
@@ -152,12 +153,52 @@ esac
   const mjuNewsStub = path.join(stubBin, "mju-news");
   await fs.writeFile(mjuNewsStub, `#!/usr/bin/env bash
 set -euo pipefail
+if [[ "\${MJU_NEWS_SKIP_VIEW:-}" != "1" ]]; then
+  echo "MJU_NEWS_SKIP_VIEW=1 is required for helper-owned webviews" >&2
+  exit 4
+fi
 printf '%s\\n' "$@" > "${toBashPath(mjuNewsArgs)}"
-printf '{"viewUrl":"http://view.local/%s","ok":true}\\n' "\${2:-unknown}"
+MODE="\${2:-unknown}"
+if [[ "$MODE" == "timetable" ]]; then
+  cat <<'JSON'
+{"total":1,"items":[{"courseTitle":"AI프로그래밍","category":"major","credit":3,"meetings":[{"dayOfWeek":1,"rawTime":"09:00-09:50"}]}],"payloadDiagnostics":{"producer":"academic-planning.timetable","output":{"itemsCount":1}},"courseCatalogDiagnostics":{"source":"database","stages":[{"key":"reader.output","label":"reader output","count":1,"status":"ok"}]}}
+JSON
+else
+  cat <<'JSON'
+{"total":1,"items":[{"department":"컴퓨터공학전공","requirementName":"전공","requiredCredits":74}],"payloadDiagnostics":{"producer":"academic-planning.graduation-roadmap","output":{"itemsCount":1}}}
+JSON
+fi
 `, "utf8");
   await fs.chmod(mjuNewsStub, 0o755);
 
-  return { stubBin, usersRoot, mjuCalls, mjuNewsArgs };
+  const curlStub = path.join(stubBin, "curl");
+  await fs.writeFile(curlStub, `#!/usr/bin/env bash
+set -euo pipefail
+BODY=""
+previous=""
+for arg in "$@"; do
+  if [[ "$previous" == "--data-binary" ]]; then
+    BODY="\${arg#@}"
+  fi
+  previous="$arg"
+done
+if [[ -z "$BODY" ]]; then
+  echo "missing --data-binary body" >&2
+  exit 2
+fi
+cp "$BODY" "${toBashPath(viewRequest)}"
+exec ${shellQuote(bashPythonPath)} - "$BODY" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+body = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(json.dumps({"url": f"http://view.local/{body.get('dataType', 'unknown')}"}))
+PY
+`, "utf8");
+  await fs.chmod(curlStub, 0o755);
+
+  return { stubBin, usersRoot, mjuCalls, mjuNewsArgs, viewRequest };
 }
 
 async function runHelper(fixture, args, env = {}) {
@@ -196,7 +237,9 @@ bashTest("academic planning helper enriches graduation roadmap calls with MSI co
   ]);
 
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /"viewUrl":"http:\/\/view\.local\/graduation-roadmap"/);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.viewUrl, "http://view.local/graduation");
+  assert.equal(output.academicPlanningHelperDiagnostics.producer, "mju-academic-planning-helper");
 
   const args = await readArgs(fixture.mjuNewsArgs);
   assert.deepEqual(args.slice(0, 2), ["academic-planning", "graduation-roadmap"]);
@@ -212,6 +255,11 @@ bashTest("academic planning helper enriches graduation roadmap calls with MSI co
   assert.match(mjuCalls, /msi timetable/);
   assert.match(mjuCalls, /msi department-timetable/);
   assert.doesNotMatch(mjuCalls, /ucheck/);
+
+  const request = JSON.parse(await fs.readFile(fixture.viewRequest, "utf8"));
+  assert.equal(request.dataType, "graduation");
+  assert.equal(request.rawData.academicPlanningHelperDiagnostics.producer, "mju-academic-planning-helper");
+  assert.equal(request.rawData.academicPlanningHelperDiagnostics.mjuNewsOutput.hasPayloadDiagnostics, true);
 });
 
 bashTest("academic planning helper routes timetable generation without UCheck", async (t) => {
@@ -228,7 +276,9 @@ bashTest("academic planning helper routes timetable generation without UCheck", 
   ]);
 
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /"viewUrl":"http:\/\/view\.local\/timetable"/);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.viewUrl, "http://view.local/timetable-planner");
+  assert.equal(output.academicPlanningHelperDiagnostics.producer, "mju-academic-planning-helper");
 
   const args = await readArgs(fixture.mjuNewsArgs);
   assert.deepEqual(args.slice(0, 2), ["academic-planning", "timetable"]);
@@ -243,6 +293,11 @@ bashTest("academic planning helper routes timetable generation without UCheck", 
   assert.match(mjuCalls, /msi grade-history/);
   assert.match(mjuCalls, /msi department-timetable/);
   assert.doesNotMatch(mjuCalls, /ucheck/);
+
+  const request = JSON.parse(await fs.readFile(fixture.viewRequest, "utf8"));
+  assert.equal(request.dataType, "timetable-planner");
+  assert.equal(request.rawData.academicPlanningHelperDiagnostics.producer, "mju-academic-planning-helper");
+  assert.equal(request.rawData.academicPlanningHelperDiagnostics.mjuNewsOutput.hasCourseCatalogDiagnostics, true);
 });
 
 bashTest("academic planning helper reports a specific grade-history menu context failure", async (t) => {

--- a/test/timetable-planner-renderer.test.cjs
+++ b/test/timetable-planner-renderer.test.cjs
@@ -130,6 +130,15 @@ test("timetable planner renders temporary catalog diagnostics", () => {
       { courseTitle: "Data Structures", category: "major", credit: 3, meetings: [{ dayOfWeek: 1, rawTime: "09:00-09:50" }] },
       { courseTitle: "Writing", category: "liberal", credit: 2, meetings: [{ dayOfWeek: 2, rawTime: "10:00-10:50" }] },
     ],
+    academicPlanningHelperDiagnostics: {
+      producer: "mju-academic-planning-helper",
+      mode: "timetable",
+      dataType: "timetable-planner",
+      runtime: { mjuNewsPath: "/usr/local/bin/mju-news", skipNestedMjuNewsView: true },
+      context: { department: "15611 컴퓨터공학전공", year: "2026", termCode: "10" },
+      mjuNewsOutput: { hasPayloadDiagnostics: true, hasCourseCatalogDiagnostics: true, itemsCount: 2 },
+      topLevelKeys: ["items", "query"],
+    },
     courseCatalogDiagnostics: {
       source: "database",
       scope: { year: 2026, termCode: "10", department: "15611 컴퓨터공학전공" },
@@ -158,6 +167,8 @@ test("timetable planner renders temporary catalog diagnostics", () => {
   assert.match(html, /data-diag-stage="db.term.all"/);
   assert.match(html, /data-diag-stage="db.term.departmentMatched"/);
   assert.match(html, /data-diag-stage="reader.output"/);
+  assert.match(html, /helper 실행/);
+  assert.match(html, /mju-academic-planning-helper/);
   assert.match(html, /data-diag-stage="ui.completedExcluded"/);
   assert.match(html, /diagnostic hint/);
   assert.match(html, /major <em>1<\/em>/);


### PR DESCRIPTION
## 요약

시간표 설계/졸업 로드맵 웹뷰가 최신 렌더러로 열려도 최종 payload에 wrapper/reader 진단이 빠지는 문제를 보강했습니다.

## 왜 필요한가

현재 운영 웹뷰는 전공 과목이 0개로 보이지만, payload 안에 helper/wrapper/reader 단계 진단이 없어 원인이 다음 중 무엇인지 구분하기 어렵습니다.

- DB/import 단계에서 전공 강의가 누락됨
- reader 학과 필터가 전공 강의를 잃음
- wrapper가 만든 payload가 최종 웹뷰 저장 전에 바뀜
- 오래된/다른 저장 경로가 사용됨

이번 변경은 `mju-academic-planning` helper가 최종 웹뷰 저장을 직접 소유하고, 그 시점의 helper 진단을 rawData에 반드시 포함하도록 합니다.

## 변경 내용

- `mju-news`에 `MJU_NEWS_SKIP_VIEW=1` 모드를 추가해 nested 실행에서는 stdout만 반환할 수 있게 했습니다.
- `mju-academic-planning`이 nested `mju-news` 결과에 `academicPlanningHelperDiagnostics`를 붙인 뒤 직접 view API에 POST합니다.
- view renderer 임시 진단 카드에서 helper 실행 경로, nested output 상태, payload key/count를 표시합니다.
- helper-owned view 경로에서 wrapper 진단이 없어도 모호한 W0 대신 helper 기준 힌트를 보여줍니다.

## 확인 방법

다음 배포 후 Discord에서 `시간표 설계` 또는 `졸업 로드맵`을 다시 열면 임시 진단 카드에 `helper 실행` 섹션이 표시되어야 합니다.

확인할 값:

- `producer: mju-academic-planning-helper`
- `mjuNewsOutput.hasPayloadDiagnostics`
- `mjuNewsOutput.hasCourseCatalogDiagnostics`
- `mjuNewsOutput.hasDataReadiness`
- `mjuNewsPath`
- query/context의 학과, 연도, 학기

이 값으로 전공 0개 원인이 DB/import인지 reader 필터인지 바로 다음 단계에서 분리할 수 있습니다.

## 검증

- `npm.cmd test`
- Git Bash PATH 포함 직접 helper 테스트: `node --test test/academic-planning-helper.test.cjs`
- `bash -n bin/mju-academic-planning`
- `bash -n bin/mju-news`

## 남은 확인

- 운영 배포 후 Discord 실호출 웹뷰에서 helper 진단 섹션 확인 필요
