### PR TITLE
docs: LMS 과제 제출 대상 해석 절차 보강

### DIFF
--- a/workspace/BOOTSTRAP.md
+++ b/workspace/BOOTSTRAP.md
@@ -271,6 +271,9 @@ LMS 온라인 영상 요청에서 과목명, 주차, 영상 항목이 부족하�
 - 사용자가 "보통으로", "만족으로"처럼 말한 만족도 멘트를 `--instruction`으로 전달하세요. 별도 신호가 없으면 CLI 기본값은 보통입니다.
 - 사용자가 처음에 "강의평가 해줘"라고 요청한 것은 제출 실행 승인입니다. 별도 확인 질문으로 흐름을 막지 마세요.
 - LMS 과제 제출은 사용자가 첨부한 파일, 사용자가 준 텍스트, 사용자가 작성한 초안을 정리한 결과만 제출합니다. 사용자가 처음에 "과제 제출해줘"라고 요청한 것은 제출 실행 승인입니다.
+- 과제 제출 요청에서 "캡스톤디자인: 최종 보고서(2차) 과제"처럼 과목명과 과제명이 섞여 있으면 전체 문자열을 `--course`에 넣지 마세요. 반드시 `mju lms +unsubmitted --all-courses` 또는 `mju lms +due-assignments --all-courses`로 전체 과제 목록을 먼저 조회하고, 결과 JSON의 `courseTitle`, `title`, `kjkey`, `rtSeq`로 제출 대상을 하나로 확정하세요.
+- Discord 첨부파일 컨텍스트에 `localPath`가 있으면 그 값을 제출 파일 경로로 사용하세요. 대상이 하나로 확정되면 `--course`보다 `--kjkey`를 우선 사용해 `mju lms assignments check-submission --kjkey KJKEY --rt-seq RT_SEQ --local-files LOCAL_PATH`를 먼저 실행하고, 통과 시 `submit --kjkey KJKEY --rt-seq RT_SEQ --local-files LOCAL_PATH --content-source user-file`로 제출하세요.
+- LMS가 접근 권한 없음, 강의실 진입 실패, 과목 없음 오류를 반환하면 즉시 사용자에게 직접 확인하라고 답하지 마세요. 먼저 `mju auth status`, `mju lms courses list`, `mju lms +unsubmitted --all-courses`를 순서대로 실행해 로그인 상태와 현재 과목/과제 목록을 재확인하세요. 대상이 하나로 다시 확인되면 `kjkey`와 `rtSeq`로 재시도하고, 그래도 없거나 여러 개면 후보를 짧게 보여주고 선택을 요청하세요.
 - 제출 도구가 다중 대상 선택, 기존 첨부 보존 불가, 제출 불가 상태를 차단하면 그 차단 이유를 사용자에게 알려주세요.
 
 ### 데이터 표시 절차


### PR DESCRIPTION
## 변경 내용
- Discord 과제 제출 요청에서 과목명과 과제명이 섞여 있으면 전체 문자열을 `--course`로 쓰지 않도록 런타임 지침을 보강했습니다.
- `+unsubmitted --all-courses` 또는 `+due-assignments --all-courses`로 과제 목록을 조회한 뒤 `courseTitle`, `title`, `kjkey`, `rtSeq`로 제출 대상을 확정하도록 했습니다.
- Discord 첨부파일 `localPath`를 그대로 제출 파일로 사용하고, `--kjkey` 기반 `check-submission` 후 `submit`을 수행하도록 명시했습니다.
- 접근 권한 없음/강의실 진입 실패/과목 없음 오류가 나면 사용자에게 바로 넘기지 않고 로그인 상태, 강의 목록, 미제출 과제 목록을 재확인한 뒤 재시도하도록 했습니다.

## 검증
- `npm run build`
- `npm test`는 로컬에 PowerShell(`pwsh`/`powershell`)이 없어 smoke-test 스크립트에서 `spawnSync`가 `ENOENT`로 실패했습니다. 코드 변경 범위와 직접 관련 없는 로컬 실행 환경 문제입니다.