### PR TITLE
[codex] Stop current timetable webviews

### DIFF
--- a/bin/mju
+++ b/bin/mju
@@ -6,7 +6,7 @@
 #   lms +action-items  → action-items
 #   lms +unsubmitted   → unsubmitted
 #   lms +unread-notices → unread-notices
-#   msi timetable      → timetable
+#   msi timetable      -> no automatic webview
 #   msi course-scores  → course-scores
 #   msi grade-history  → grade-history
 #   msi graduation     → disabled while graduation roadmap is the only user-facing graduation view
@@ -62,7 +62,6 @@ detect_datatype() {
     *"lms +unsubmitted"*) echo "unsubmitted" ;;
     *"lms +unread-notices"*) echo "unread-notices" ;;
     *"lms +digest"*) echo "action-items" ;;
-    *"msi timetable"*) echo "timetable" ;;
     *"msi course-scores"*) echo "course-scores" ;;
     *"msi grade-history"*) echo "grade-history" ;;
     *"ucheck"*) echo "attendance" ;;

--- a/skills/mju-msi/SKILL.md
+++ b/skills/mju-msi/SKILL.md
@@ -18,6 +18,7 @@ metadata:
 ## 자주 쓰는 명령
 - 현재 수강 시간표 조회: `mju --app-dir /data/users/<DISCORD_USER_ID> --format json msi timetable`
   - 선택 옵션: `--year <연도> --term-code <학기코드>`
+  - 현재 시간표 조회는 웹뷰를 반환하지 않습니다. 결과 JSON의 시간표 항목을 직접 요약하고 `viewUrl`을 만들거나 기대하지 마세요.
 - 요일별 마지막 수업 종료 시각 조회: `mju --app-dir /data/users/<DISCORD_USER_ID> --format json msi +last-class-times`
   - 셔틀 출발 알림처럼 마지막 수업 종료 시각만 필요한 자동화에서 사용합니다.
 - 현재 학기 성적/점수: `mju --app-dir /data/users/<DISCORD_USER_ID> --format json msi course-scores`

--- a/test/mju-wrapper-course-scores.test.cjs
+++ b/test/mju-wrapper-course-scores.test.cjs
@@ -141,15 +141,15 @@ bashTest("mju wrapper routes course-scores to the view API and injects viewUrl",
   assert.equal(output.courses[0].title, "0752 - 시스템클라우드보안");
 });
 
-for (const legacyCommand of ["current-grades", "grades", "graduation"]) {
-  bashTest(`mju wrapper leaves msi ${legacyCommand} output unviewed`, async (t) => {
+for (const unviewedCommand of ["timetable", "current-grades", "grades", "graduation"]) {
+  bashTest(`mju wrapper leaves msi ${unviewedCommand} output unviewed`, async (t) => {
     const fixture = await createWrapperFixture(t, {
       items: [{ courseTitle: "시스템클라우드보안", grade: "A+" }],
     });
 
     const result = await run("bash", ["-lc", wrapperCommand(fixture, [
       "msi",
-      legacyCommand,
+      unviewedCommand,
       "--app-dir",
       toBashPath(path.join(fixture.testDir, "app")),
       "--format",

--- a/test/msi-skill-override.test.cjs
+++ b/test/msi-skill-override.test.cjs
@@ -5,6 +5,16 @@ const test = require("node:test");
 
 const root = path.resolve(__dirname, "..");
 
+test("runtime instructions keep current timetable responses unviewed", () => {
+  const bootstrap = fs.readFileSync(path.join(root, "workspace", "BOOTSTRAP.md"), "utf8");
+  const msiSkill = fs.readFileSync(path.join(root, "skills", "mju-msi", "SKILL.md"), "utf8");
+
+  assert.match(bootstrap, /Current MSI timetable requests are intentionally not webview-backed/);
+  assert.match(bootstrap, /Exception: current MSI timetable lookup/);
+  assert.match(bootstrap, /Current MSI timetable has no expiring webview link/);
+  assert.match(msiSkill, /viewUrl/);
+});
+
 test("local mju-msi skill overrides current-term grades to course-scores", () => {
   const skill = fs.readFileSync(path.join(root, "skills", "mju-msi", "SKILL.md"), "utf8");
 
@@ -115,7 +125,8 @@ test("webview wrappers keep academic planning separate from legacy MSI and UChec
   assert.match(mjuNewsWrapper, /"timetable-planner"\) echo "시간표 설계"/);
   assert.match(mjuNewsWrapper, /"graduation"\) echo "졸업 로드맵"/);
 
-  assert.match(mjuWrapper, /msi timetable"\*\) echo "timetable"/);
+  assert.doesNotMatch(mjuWrapper, /msi timetable"\*\) echo "timetable"/);
+  assert.match(mjuWrapper, /msi timetable\s+-> no automatic webview/);
   assert.match(mjuWrapper, /MJU_SKIP_VIEW/);
   assert.doesNotMatch(mjuWrapper, /msi graduation"\*\) echo "graduation"/);
   assert.match(mjuWrapper, /ucheck"\*\) echo "attendance"/);

--- a/workspace/BOOTSTRAP.md
+++ b/workspace/BOOTSTRAP.md
@@ -231,7 +231,7 @@ LMS 온라인 영상 요청에서 과목명, 주차, 영상 항목이 부족하�
 | 유저 의도 | 사용할 명령 | dataType (자동) |
 |---|---|---|
 | "시간표 설계", "시간표 짜줘", "랜덤 시간표", "추천 시간표", "전공 3개 교양 2개", "요일/교시 제외", "시간 안 겹치게" | `mju-timetable-planner {DISCORD_USER_ID} --format json` 또는 명시 학기 요청 시 `mju-timetable-planner {DISCORD_USER_ID} --year YYYY --term-code 10|20 --format json` | `timetable-planner` |
-| "내 현재 시간표", "이번 학기 수강 시간표", "지금 듣는 수업 시간표" | `mju msi timetable --app-dir /data/users/{DISCORD_USER_ID} --format json` | `timetable` |
+| "내 현재 시간표", "이번 학기 수강 시간표", "지금 듣는 수업 시간표" | `mju msi timetable --app-dir /data/users/{DISCORD_USER_ID} --format json` | 없음 (`viewUrl` 없음) |
 | "출석", "유체크", "결석", "출석 알림" | `mju ucheck lectures list --app-dir /data/users/{DISCORD_USER_ID} --format json` 또는 `mju ucheck attendance --course "<과목명>" --app-dir /data/users/{DISCORD_USER_ID} --format json` | `attendance` |
 | "졸업요건", "내 졸업요건", "졸업학점", "졸업 로드맵", "졸업까지", "졸업까지 뭐 남았어", "내가 뭘 들었고 뭘 들어야 해", "영역별 졸업요건" | `mju-graduation-roadmap {DISCORD_USER_ID} --format json` | `graduation` |
 | "MSI 졸업요건 원본", "학교 시스템 졸업사정 그대로", "MSI 원본만" | `mju-graduation-roadmap {DISCORD_USER_ID} --format json` | `graduation` |
@@ -244,13 +244,19 @@ LMS 온라인 영상 요청에서 과목명, 주차, 영상 항목이 부족하�
 
 시간표 설계 요청에서 `mju ucheck`를 호출하면 출석 웹뷰가 열립니다. "시간표"라는 단어가 있어도 설계/추천/랜덤/전공·교양 개수/요일 제외/교시 제외/다음 학기 맥락이면 절대 `ucheck`를 쓰지 마세요. UCheck는 사용자가 출석/결석/유체크/출석 알림을 명시한 경우에만 사용합니다.
 
+Current MSI timetable requests are intentionally not webview-backed. `mju msi timetable --app-dir /data/users/{DISCORD_USER_ID} --format json` returns JSON without `viewUrl`; answer from the timetable entries directly. This is separate from timetable planning, which still uses `mju-timetable-planner` and returns the `timetable-planner` webview.
+
 ## 데이터 표시 — 3단계
 
 `mju lms`, `mju msi`, `mju ucheck`, `mju library`, `mju-news` 실행 시 **결과 JSON에 `viewUrl` 필드**가 자동으로 들어옵니다 (조회성 커맨드 한정). 이 URL은 웹뷰 링크입니다.
 
+Exception: current MSI timetable lookup (`mju msi timetable`) does not inject `viewUrl`; do not fabricate or request a webview link for it.
+
 ### 만료된 웹뷰 링크 재발급
 
 사용자가 "링크가 만료됐어", "만료되었다는데", "다시 열어줘", "다시 보내줘"처럼 말하면 이전 대화의 `viewUrl`을 재사용하지 마세요. 웹뷰 링크 만료는 SSO 세션 만료가 아니므로 "DM으로 다시 로그인/세션 확인"이라고 답하지 마세요. 직전 요청 의도가 시간표 설계면 `mju-timetable-planner {DISCORD_USER_ID} --format json`, 졸업 로드맵이면 `mju-graduation-roadmap {DISCORD_USER_ID} --format json`, 현재 시간표/성적/과제/학식 등 다른 기능이면 해당 기능의 원래 조회 명령을 다시 실행해 새 `viewUrl`을 발급하세요. 단, 직전 시간표 설계 요청에 `2026년 1학기`처럼 연도/학기가 명시되어 있었다면 재발급 명령에도 동일한 `--year`와 `--term-code`를 유지하세요. 직전 의도를 확정할 수 없을 때만 어떤 화면을 다시 열지 짧게 물어보세요.
+
+Current MSI timetable has no expiring webview link. If the previous intent was current timetable, rerun `mju msi timetable --app-dir /data/users/{DISCORD_USER_ID} --format json` and answer from JSON instead of issuing a new `viewUrl`.
 
 ### 성적 조회 — 의도와 명령 매핑 (중요)
 


### PR DESCRIPTION
## What changed

- Removed `mju msi timetable` from the `mju` wrapper's automatic webview mapping.
- Kept timetable planning on the separate `mju-timetable-planner` / `timetable-planner` webview path.
- Updated runtime instructions and MSI skill guidance so current timetable responses are summarized from JSON without `viewUrl`.
- Added regression coverage that treats MSI timetable like the other unviewed MSI commands.

## Why

Plain current timetable requests should not return a personal webview link. That behavior was leaking from the wrapper's old `dataType=timetable` mapping and made current timetable lookup look like the separate timetable planning workflow.

## Validation

- `cmd /c npm test` passed: 112 pass, 16 skipped.
- PowerShell wrapper mapping check passed: `msi timetable` no longer maps to `timetable`, while `msi course-scores` still maps to `course-scores`.

## Notes

The bash wrapper execution tests are skipped on this Windows environment because `C:\Windows\System32\bash.exe` is WSL bash and does not have Node available inside it. The full Node test suite and static wrapper contract check both passed.